### PR TITLE
Subflows

### DIFF
--- a/common/test_flows/media.json
+++ b/common/test_flows/media.json
@@ -395,7 +395,7 @@
     "contact_creation": "login",
     "expires": 10080,
     "saved_on": "2016-04-12T15:58:45.306277Z",
-    "id": 35628,
+    "uuid": "123456e87-3466-4468-ab11-0e8d84c0e9fb",
     "revision": 137
   }
 }

--- a/common/test_flows/subflow.json
+++ b/common/test_flows/subflow.json
@@ -1,49 +1,49 @@
 {
-  "campaigns": [], 
-  "version": 8, 
-  "site": "https://textit.in", 
+  "campaigns": [],
+  "version": 9,
+  "site": "https://textit.in",
   "flows": [
     {
-      "base_language": "eng", 
+      "base_language": "eng",
       "action_sets": [
         {
-          "y": 0, 
-          "x": 100, 
-          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651", 
-          "uuid": "accd6da2-1c2c-4962-bd66-51f75c3d89d8", 
+          "y": 0,
+          "x": 100,
+          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651",
+          "uuid": "accd6da2-1c2c-4962-bd66-51f75c3d89d8",
           "actions": [
             {
               "msg": {
                 "eng": "This is a parent flow. What would you like to do?"
-              }, 
+              },
               "type": "reply"
             }
           ]
-        }, 
+        },
         {
-          "y": 65, 
-          "x": 590, 
-          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651", 
-          "uuid": "2be31f2e-e38c-42da-8626-7b668f5c2bcb", 
+          "y": 65,
+          "x": 590,
+          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651",
+          "uuid": "2be31f2e-e38c-42da-8626-7b668f5c2bcb",
           "actions": [
             {
               "msg": {
                 "eng": "I don't recognize that command."
-              }, 
+              },
               "type": "reply"
             }
           ]
-        }, 
+        },
         {
-          "y": 386, 
-          "x": 341, 
+          "y": 386,
+          "x": 341,
           "destination": "accd6da2-1c2c-4962-bd66-51f75c3d89d8",
-          "uuid": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6", 
+          "uuid": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6",
           "actions": [
             {
               "msg": {
                 "eng": "@flow.subflow.category: You picked @child.color.category."
-              }, 
+              },
               "type": "reply"
             }
           ]
@@ -62,66 +62,66 @@
             }
           ]
         }
-      ], 
-      "version": 8, 
-      "flow_type": "F", 
-      "entry": "accd6da2-1c2c-4962-bd66-51f75c3d89d8", 
+      ],
+      "version": 8,
+      "flow_type": "F",
+      "entry": "accd6da2-1c2c-4962-bd66-51f75c3d89d8",
       "rule_sets": [
         {
-          "uuid": "c89414cf-7c07-42ce-9135-86a5a036f651", 
-          "webhook_action": null, 
+          "uuid": "c89414cf-7c07-42ce-9135-86a5a036f651",
+          "webhook_action": null,
           "rules": [
             {
               "test": {
                 "test": {
                   "eng": "color"
-                }, 
+                },
                 "type": "contains_any"
-              }, 
+              },
               "category": {
                 "eng": "Color"
-              }, 
-              "destination": "546c368a-90ef-4145-8da6-20b8bb198b31", 
-              "uuid": "b8eddbd7-3c31-46bb-895c-543bcba447bc", 
+              },
+              "destination": "546c368a-90ef-4145-8da6-20b8bb198b31",
+              "uuid": "b8eddbd7-3c31-46bb-895c-543bcba447bc",
               "destination_type": "R"
-            }, 
+            },
             {
               "test": {
-                "test": "true", 
+                "test": "true",
                 "type": "true"
-              }, 
+              },
               "category": {
                 "eng": "Other"
-              }, 
-              "destination": "2be31f2e-e38c-42da-8626-7b668f5c2bcb", 
-              "uuid": "806cdd98-5104-4ebe-9ffc-4c884973ca5f", 
+              },
+              "destination": "2be31f2e-e38c-42da-8626-7b668f5c2bcb",
+              "uuid": "806cdd98-5104-4ebe-9ffc-4c884973ca5f",
               "destination_type": "A"
             }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "wait_message", 
+          ],
+          "webhook": null,
+          "ruleset_type": "wait_message",
           "label": "kind",
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 154, 
-          "x": 278, 
+          "operand": "@step.value",
+          "finished_key": null,
+          "response_type": "",
+          "y": 154,
+          "x": 278,
           "config": {}
-        }, 
+        },
         {
-          "uuid": "546c368a-90ef-4145-8da6-20b8bb198b31", 
-          "webhook_action": null, 
+          "uuid": "546c368a-90ef-4145-8da6-20b8bb198b31",
+          "webhook_action": null,
           "rules": [
             {
               "test": {
                 "type": "subflow",
                 "exit_type": "completed"
-              }, 
+              },
               "category": {
                 "eng": "Complete"
-              }, 
-              "destination": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6", 
-              "uuid": "d163cfa4-5c75-4735-a0e0-d5a662001f80", 
+              },
+              "destination": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6",
+              "uuid": "d163cfa4-5c75-4735-a0e0-d5a662001f80",
               "destination_type": "A"
             },
             {
@@ -136,139 +136,139 @@
               "uuid": "12345678-5c75-4735-a0e0-d5a662001f80",
               "destination_type": "A"
             }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "subflow", 
-          "label": "Subflow", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 272, 
-          "x": 248, 
+          ],
+          "webhook": null,
+          "ruleset_type": "subflow",
+          "label": "Subflow",
+          "operand": "@step.value",
+          "finished_key": null,
+          "response_type": "",
+          "y": 272,
+          "x": 248,
           "config": {
             "flow": {
-              "id": 35637,
+              "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93",
               "name": "Child Flow"
             }
           }
         }
-      ], 
+      ],
       "metadata": {
-        "expires": 10080, 
-        "revision": 24, 
-        "id": 35636, 
-        "name": "Parent Flow", 
+        "expires": 10080,
+        "revision": 24,
+        "uuid": "7c1dee9b-af4c-407b-a269-5553e59149e1",
+        "name": "Parent Flow",
         "saved_on": "2016-04-26T23:13:32.368766Z"
       }
-    }, 
+    },
     {
-      "base_language": "eng", 
+      "base_language": "eng",
       "action_sets": [
         {
-          "y": 0, 
-          "x": 100, 
-          "destination": "fc561730-70f8-4426-b3c7-da237e88331e", 
-          "uuid": "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb", 
+          "y": 0,
+          "x": 100,
+          "destination": "fc561730-70f8-4426-b3c7-da237e88331e",
+          "uuid": "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb",
           "actions": [
             {
               "msg": {
                 "eng": "What @parent.kind do you like?"
-              }, 
+              },
               "type": "reply"
             }
           ]
-        }, 
+        },
         {
-          "y": 160, 
-          "x": 730, 
-          "destination": "fc561730-70f8-4426-b3c7-da237e88331e", 
-          "uuid": "8d80451e-f457-4438-9f91-75b3232d1826", 
+          "y": 160,
+          "x": 730,
+          "destination": "fc561730-70f8-4426-b3c7-da237e88331e",
+          "uuid": "8d80451e-f457-4438-9f91-75b3232d1826",
           "actions": [
             {
               "msg": {
                 "eng": "Try again."
-              }, 
+              },
               "type": "reply"
             }
           ]
         }
-      ], 
-      "version": 8, 
-      "flow_type": "F", 
-      "entry": "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb", 
+      ],
+      "version": 8,
+      "flow_type": "F",
+      "entry": "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb",
       "rule_sets": [
         {
-          "uuid": "fc561730-70f8-4426-b3c7-da237e88331e", 
-          "webhook_action": null, 
+          "uuid": "fc561730-70f8-4426-b3c7-da237e88331e",
+          "webhook_action": null,
           "rules": [
             {
               "test": {
                 "test": {
                   "eng": "Red"
-                }, 
+                },
                 "type": "contains_any"
-              }, 
+              },
               "category": {
                 "eng": "Red"
-              }, 
+              },
               "uuid": "8c25293a-5864-46b0-b61a-c9815ed03fdf"
-            }, 
+            },
             {
               "test": {
                 "test": {
                   "eng": "Green"
-                }, 
+                },
                 "type": "contains_any"
-              }, 
+              },
               "category": {
                 "eng": "Green"
-              }, 
+              },
               "uuid": "e04e08b0-9f64-459f-b4d3-f301c5a825ff"
-            }, 
+            },
             {
               "test": {
                 "test": {
                   "eng": "Blue"
-                }, 
+                },
                 "type": "contains_any"
-              }, 
+              },
               "category": {
                 "eng": "Blue"
-              }, 
+              },
               "uuid": "5cf35b6a-fe47-4ca4-bc59-9d9efb6348f1"
-            }, 
+            },
             {
               "test": {
-                "test": "true", 
+                "test": "true",
                 "type": "true"
-              }, 
+              },
               "category": {
                 "eng": "Other"
-              }, 
-              "destination": "8d80451e-f457-4438-9f91-75b3232d1826", 
-              "uuid": "e2790305-7662-4118-b27c-21e3cfd95317", 
+              },
+              "destination": "8d80451e-f457-4438-9f91-75b3232d1826",
+              "uuid": "e2790305-7662-4118-b27c-21e3cfd95317",
               "destination_type": "A"
             }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "wait_message", 
-          "label": "Color", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 110, 
-          "x": 254, 
+          ],
+          "webhook": null,
+          "ruleset_type": "wait_message",
+          "label": "Color",
+          "operand": "@step.value",
+          "finished_key": null,
+          "response_type": "",
+          "y": 110,
+          "x": 254,
           "config": {}
         }
-      ], 
+      ],
       "metadata": {
-        "expires": 10080, 
-        "revision": 11, 
-        "id": 35637, 
-        "name": "Child Flow", 
+        "expires": 10080,
+        "revision": 11,
+        "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93",
+        "name": "Child Flow",
         "saved_on": "2016-04-26T21:34:39.525175Z"
       }
     }
-  ], 
+  ],
   "triggers": []
 }

--- a/common/test_flows/subflow.json
+++ b/common/test_flows/subflow.json
@@ -1,0 +1,274 @@
+{
+  "campaigns": [], 
+  "version": 8, 
+  "site": "https://textit.in", 
+  "flows": [
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "y": 0, 
+          "x": 100, 
+          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651", 
+          "uuid": "accd6da2-1c2c-4962-bd66-51f75c3d89d8", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "This is a parent flow. What would you like to do?"
+              }, 
+              "type": "reply"
+            }
+          ]
+        }, 
+        {
+          "y": 65, 
+          "x": 590, 
+          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651", 
+          "uuid": "2be31f2e-e38c-42da-8626-7b668f5c2bcb", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "I don't recognize that command."
+              }, 
+              "type": "reply"
+            }
+          ]
+        }, 
+        {
+          "y": 386, 
+          "x": 341, 
+          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651",
+          "uuid": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "@flow.subflow.category: You picked @child.color.category."
+              }, 
+              "type": "reply"
+            }
+          ]
+        },
+        {
+          "y": 386,
+          "x": 641,
+          "destination": null,
+          "uuid": "12345678-6dde-47ae-84e5-40383bafb0d6",
+          "actions": [
+            {
+              "msg": {
+                "eng": "You expired out of the subflow"
+              },
+              "type": "reply"
+            }
+          ]
+        }
+      ], 
+      "version": 8, 
+      "flow_type": "F", 
+      "entry": "accd6da2-1c2c-4962-bd66-51f75c3d89d8", 
+      "rule_sets": [
+        {
+          "uuid": "c89414cf-7c07-42ce-9135-86a5a036f651", 
+          "webhook_action": null, 
+          "rules": [
+            {
+              "test": {
+                "test": {
+                  "eng": "color"
+                }, 
+                "type": "contains_any"
+              }, 
+              "category": {
+                "eng": "Color"
+              }, 
+              "destination": "546c368a-90ef-4145-8da6-20b8bb198b31", 
+              "uuid": "b8eddbd7-3c31-46bb-895c-543bcba447bc", 
+              "destination_type": "R"
+            }, 
+            {
+              "test": {
+                "test": "true", 
+                "type": "true"
+              }, 
+              "category": {
+                "eng": "Other"
+              }, 
+              "destination": "2be31f2e-e38c-42da-8626-7b668f5c2bcb", 
+              "uuid": "806cdd98-5104-4ebe-9ffc-4c884973ca5f", 
+              "destination_type": "A"
+            }
+          ], 
+          "webhook": null, 
+          "ruleset_type": "wait_message", 
+          "label": "kind",
+          "operand": "@step.value", 
+          "finished_key": null, 
+          "response_type": "", 
+          "y": 154, 
+          "x": 278, 
+          "config": {}
+        }, 
+        {
+          "uuid": "546c368a-90ef-4145-8da6-20b8bb198b31", 
+          "webhook_action": null, 
+          "rules": [
+            {
+              "test": {
+                "type": "subflow",
+                "exit_type": "completed"
+              }, 
+              "category": {
+                "eng": "Complete"
+              }, 
+              "destination": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6", 
+              "uuid": "d163cfa4-5c75-4735-a0e0-d5a662001f80", 
+              "destination_type": "A"
+            },
+            {
+              "test": {
+                "type": "subflow",
+                "exit_type": "expired"
+              },
+              "category": {
+                "eng": "Expired"
+              },
+              "destination": "12345678-6dde-47ae-84e5-40383bafb0d6",
+              "uuid": "12345678-5c75-4735-a0e0-d5a662001f80",
+              "destination_type": "A"
+            }
+          ], 
+          "webhook": null, 
+          "ruleset_type": "subflow", 
+          "label": "Subflow", 
+          "operand": "@step.value", 
+          "finished_key": null, 
+          "response_type": "", 
+          "y": 272, 
+          "x": 248, 
+          "config": {
+            "flow": {
+              "id": 35637,
+              "name": "Child Flow"
+            }
+          }
+        }
+      ], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 24, 
+        "id": 35636, 
+        "name": "Parent Flow", 
+        "saved_on": "2016-04-26T23:13:32.368766Z"
+      }
+    }, 
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "y": 0, 
+          "x": 100, 
+          "destination": "fc561730-70f8-4426-b3c7-da237e88331e", 
+          "uuid": "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "What @parent.kind do you like?"
+              }, 
+              "type": "reply"
+            }
+          ]
+        }, 
+        {
+          "y": 160, 
+          "x": 730, 
+          "destination": "fc561730-70f8-4426-b3c7-da237e88331e", 
+          "uuid": "8d80451e-f457-4438-9f91-75b3232d1826", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "Try again."
+              }, 
+              "type": "reply"
+            }
+          ]
+        }
+      ], 
+      "version": 8, 
+      "flow_type": "F", 
+      "entry": "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb", 
+      "rule_sets": [
+        {
+          "uuid": "fc561730-70f8-4426-b3c7-da237e88331e", 
+          "webhook_action": null, 
+          "rules": [
+            {
+              "test": {
+                "test": {
+                  "eng": "Red"
+                }, 
+                "type": "contains_any"
+              }, 
+              "category": {
+                "eng": "Red"
+              }, 
+              "uuid": "8c25293a-5864-46b0-b61a-c9815ed03fdf"
+            }, 
+            {
+              "test": {
+                "test": {
+                  "eng": "Green"
+                }, 
+                "type": "contains_any"
+              }, 
+              "category": {
+                "eng": "Green"
+              }, 
+              "uuid": "e04e08b0-9f64-459f-b4d3-f301c5a825ff"
+            }, 
+            {
+              "test": {
+                "test": {
+                  "eng": "Blue"
+                }, 
+                "type": "contains_any"
+              }, 
+              "category": {
+                "eng": "Blue"
+              }, 
+              "uuid": "5cf35b6a-fe47-4ca4-bc59-9d9efb6348f1"
+            }, 
+            {
+              "test": {
+                "test": "true", 
+                "type": "true"
+              }, 
+              "category": {
+                "eng": "Other"
+              }, 
+              "destination": "8d80451e-f457-4438-9f91-75b3232d1826", 
+              "uuid": "e2790305-7662-4118-b27c-21e3cfd95317", 
+              "destination_type": "A"
+            }
+          ], 
+          "webhook": null, 
+          "ruleset_type": "wait_message", 
+          "label": "Color", 
+          "operand": "@step.value", 
+          "finished_key": null, 
+          "response_type": "", 
+          "y": 110, 
+          "x": 254, 
+          "config": {}
+        }
+      ], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 11, 
+        "id": 35637, 
+        "name": "Child Flow", 
+        "saved_on": "2016-04-26T21:34:39.525175Z"
+      }
+    }
+  ], 
+  "triggers": []
+}

--- a/common/test_flows/subflow.json
+++ b/common/test_flows/subflow.json
@@ -37,7 +37,7 @@
         {
           "y": 386, 
           "x": 341, 
-          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651",
+          "destination": "accd6da2-1c2c-4962-bd66-51f75c3d89d8",
           "uuid": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6", 
           "actions": [
             {

--- a/java/src/main/java/io/rapidpro/flows/RunnerBuilder.java
+++ b/java/src/main/java/io/rapidpro/flows/RunnerBuilder.java
@@ -2,9 +2,13 @@ package io.rapidpro.flows;
 
 import io.rapidpro.expressions.EvaluatorBuilder;
 import io.rapidpro.expressions.evaluator.Evaluator;
+import io.rapidpro.flows.definition.Flow;
 import io.rapidpro.flows.runner.Location;
 import io.rapidpro.flows.runner.Runner;
 import org.threeten.bp.Instant;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Builder for runner instances
@@ -16,6 +20,16 @@ public class RunnerBuilder {
     protected Location.Resolver m_locationResolver;
 
     protected Instant m_now;
+
+    protected List<Flow> m_flows;
+
+    public RunnerBuilder(List<Flow> flows) {
+        m_flows = flows;
+    }
+
+    public RunnerBuilder() {
+        m_flows = new ArrayList<>();
+    }
 
     public RunnerBuilder withTemplateEvaluator(Evaluator templateEvaluator) {
         m_templateEvaluator = templateEvaluator;
@@ -36,7 +50,7 @@ public class RunnerBuilder {
         if (m_templateEvaluator == null) {
             m_templateEvaluator = new EvaluatorBuilder()
                     .withExpressionPrefix('@')
-                    .withAllowedTopLevels(new String[]{"channel", "contact", "date", "extra", "flow", "step"})
+                    .withAllowedTopLevels(new String[]{"channel", "contact", "date", "extra", "flow", "step", "parent", "child"})
                     .build();
         }
 
@@ -49,6 +63,6 @@ public class RunnerBuilder {
             };
         }
 
-        return new Runner(m_templateEvaluator, m_locationResolver, m_now);
+        return new Runner(m_templateEvaluator, m_locationResolver, m_now, m_flows);
     }
 }

--- a/java/src/main/java/io/rapidpro/flows/definition/ActionSet.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/ActionSet.java
@@ -3,6 +3,8 @@ package io.rapidpro.flows.definition;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.rapidpro.flows.definition.actions.Action;
+import io.rapidpro.flows.definition.actions.message.MessageAction;
+import io.rapidpro.flows.definition.actions.message.SendAction;
 import io.rapidpro.flows.runner.Input;
 import io.rapidpro.flows.runner.RunState;
 import io.rapidpro.flows.runner.Runner;

--- a/java/src/main/java/io/rapidpro/flows/definition/Flow.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/Flow.java
@@ -238,7 +238,6 @@ public class Flow {
     }
 
     public String getUUID() {
-        System.out.println(m_metadata.toString());
         return m_metadata.get("uuid").getAsString();
     }
 

--- a/java/src/main/java/io/rapidpro/flows/definition/Flow.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/Flow.java
@@ -18,7 +18,7 @@ import java.util.*;
 public class Flow {
 
     // supported versions of the flow spec
-    public static Set<Integer> SPEC_VERSIONS = new HashSet<>(Arrays.asList(7, 8));
+    public static Set<Integer> SPEC_VERSIONS = new HashSet<>(Arrays.asList(7, 8, 9));
 
     public enum Type {
         FLOW("F"),
@@ -79,7 +79,7 @@ public class Flow {
         // keep an exhaustive record of all languages in our flow definition
         Set<String> languages = new HashSet<>();
 
-        DeserializationContext context = new DeserializationContext(new HashMap<Integer, Flow>());
+        DeserializationContext context = new DeserializationContext(new HashMap<String, Flow>());
 
         for (JsonElement asElem : obj.get("action_sets").getAsJsonArray()) {
             ActionSet actionSet = ActionSet.fromJson(asElem.getAsJsonObject(), context);
@@ -126,25 +126,25 @@ public class Flow {
      */
     public static class DeserializationContext {
 
-        protected Map<Integer,Flow> m_flows;
+        protected Map<String,Flow> m_flows;
 
         protected Map<ConnectionStart, String> m_destinationsToSet = new HashMap<>();
 
-        public DeserializationContext(Map<Integer,Flow> flows) {
+        public DeserializationContext(Map<String,Flow> flows) {
             m_flows = flows;
         }
 
         public DeserializationContext(Flow flow) {
             m_flows = new HashMap<>();
-            m_flows.put(flow.getId(), flow);
+            m_flows.put(flow.getUUID(), flow);
         }
 
         public void needsDestination(ConnectionStart start, String destinationUuid) {
             m_destinationsToSet.put(start, destinationUuid);
         }
 
-        public Flow getFlow(int flowId) {
-            return m_flows.get(flowId);
+        public Flow getFlow(String flowUUID) {
+            return m_flows.get(flowUUID);
         }
     }
 
@@ -237,8 +237,9 @@ public class Flow {
         return m_metadata;
     }
 
-    public int getId() {
-        return m_metadata.get("id").getAsInt();
+    public String getUUID() {
+        System.out.println(m_metadata.toString());
+        return m_metadata.get("uuid").getAsString();
     }
 
     public <T extends Element> T getElementByUuid(String uuid) {

--- a/java/src/main/java/io/rapidpro/flows/definition/Flow.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/Flow.java
@@ -79,7 +79,7 @@ public class Flow {
         // keep an exhaustive record of all languages in our flow definition
         Set<String> languages = new HashSet<>();
 
-        DeserializationContext context = new DeserializationContext(flow);
+        DeserializationContext context = new DeserializationContext(new HashMap<Integer, Flow>());
 
         for (JsonElement asElem : obj.get("action_sets").getAsJsonArray()) {
             ActionSet actionSet = ActionSet.fromJson(asElem.getAsJsonObject(), context);
@@ -126,20 +126,25 @@ public class Flow {
      */
     public static class DeserializationContext {
 
-        protected Flow m_flow;
+        protected Map<Integer,Flow> m_flows;
 
         protected Map<ConnectionStart, String> m_destinationsToSet = new HashMap<>();
 
+        public DeserializationContext(Map<Integer,Flow> flows) {
+            m_flows = flows;
+        }
+
         public DeserializationContext(Flow flow) {
-            m_flow = flow;
+            m_flows = new HashMap<>();
+            m_flows.put(flow.getId(), flow);
         }
 
         public void needsDestination(ConnectionStart start, String destinationUuid) {
             m_destinationsToSet.put(start, destinationUuid);
         }
 
-        public Flow getFlow() {
-            return m_flow;
+        public Flow getFlow(int flowId) {
+            return m_flows.get(flowId);
         }
     }
 
@@ -230,6 +235,10 @@ public class Flow {
 
     public JsonObject getMetadata() {
         return m_metadata;
+    }
+
+    public int getId() {
+        return m_metadata.get("id").getAsInt();
     }
 
     public <T extends Element> T getElementByUuid(String uuid) {

--- a/java/src/main/java/io/rapidpro/flows/definition/Flow.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/Flow.java
@@ -136,15 +136,15 @@ public class Flow {
 
         public DeserializationContext(Flow flow) {
             m_flows = new HashMap<>();
-            m_flows.put(flow.getUUID(), flow);
+            m_flows.put(flow.getUuid(), flow);
         }
 
         public void needsDestination(ConnectionStart start, String destinationUuid) {
             m_destinationsToSet.put(start, destinationUuid);
         }
 
-        public Flow getFlow(String flowUUID) {
-            return m_flows.get(flowUUID);
+        public Flow getFlow(String flowUuid) {
+            return m_flows.get(flowUuid);
         }
     }
 
@@ -237,7 +237,7 @@ public class Flow {
         return m_metadata;
     }
 
-    public String getUUID() {
+    public String getUuid() {
         return m_metadata.get("uuid").getAsString();
     }
 

--- a/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
@@ -116,7 +116,7 @@ public class RuleSet extends Flow.Node {
         Test.Result testResult = match.getRight();
 
         // get category in the flow base language
-        String category = rule.getCategory().getLocalized(Collections.singletonList(run.getFlow().getBaseLanguage()), "");
+        String category = rule.getCategory().getLocalized(Collections.singletonList(run.getActiveFlow().getBaseLanguage()), "");
 
         String valueAsStr = Conversions.toString(testResult.getValue(), context);
 

--- a/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
@@ -120,7 +120,7 @@ public class RuleSet extends Flow.Node {
 
         String valueAsStr = Conversions.toString(testResult.getValue(), context);
 
-        Result result = new Result(rule, valueAsStr, category, input.getValueAsText(context), input.getMedia(), step.getFlow().getUuid());
+        Result result = new Result(rule, valueAsStr, category, input.getValueAsText(context), input.getMedia(), step.getFlow());
         step.setRuleResult(result);
 
         run.updateValue(this, result, input.getTime());
@@ -210,15 +210,15 @@ public class RuleSet extends Flow.Node {
 
         protected String m_media;
 
-        protected String m_flowUuid;
+        protected Flow m_flow;
 
-        public Result(Rule rule, String value, String category, String text, String media, String flowUuid) {
+        public Result(Rule rule, String value, String category, String text, String media, Flow flow) {
             m_rule = rule;
             m_value = value;
             m_category = category;
             m_text = text;
             m_media = media;
-            m_flowUuid = flowUuid;
+            m_flow = flow;
         }
 
         public static Result fromJson(JsonElement elm, Flow.DeserializationContext context) {
@@ -231,7 +231,7 @@ public class RuleSet extends Flow.Node {
                     JsonUtils.getAsString(obj, "category"),
                     JsonUtils.getAsString(obj, "text"),
                     JsonUtils.getAsString(obj, "media"),
-                    flowUuid
+                    flow
             );
         }
 
@@ -243,7 +243,7 @@ public class RuleSet extends Flow.Node {
                     "category", m_category,
                     "text", m_text,
                     "media", m_media,
-                    "flow_uuid", m_flowUuid
+                    "flow_uuid", m_flow.getUuid()
             );
         }
 
@@ -272,10 +272,6 @@ public class RuleSet extends Flow.Node {
 
         public String getMedia() {
             return m_media;
-        }
-
-        public String getFlowUuid() {
-            return m_flowUuid;
         }
     }
 }

--- a/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
@@ -273,5 +273,7 @@ public class RuleSet extends Flow.Node {
         public String getMedia() {
             return m_media;
         }
+
+        public Flow getFlow() { return m_flow; }
     }
 }

--- a/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
@@ -66,7 +66,7 @@ public class RuleSet extends Flow.Node {
     /**
      * Get the id for our subflow if we have one
      */
-    public String getSubflowUUID() {
+    public String getSubflowUuid() {
         Object flow = m_config.get("flow");
         if (flow != null) {
             return ((Map)flow).get("uuid").toString();
@@ -119,7 +119,8 @@ public class RuleSet extends Flow.Node {
         String category = rule.getCategory().getLocalized(Collections.singletonList(run.getFlow().getBaseLanguage()), "");
 
         String valueAsStr = Conversions.toString(testResult.getValue(), context);
-        Result result = new Result(rule, valueAsStr, category, input.getValueAsText(context), input.getMedia(), step.getFlow().getUUID());
+
+        Result result = new Result(rule, valueAsStr, category, input.getValueAsText(context), input.getMedia(), step.getFlow().getUuid());
         step.setRuleResult(result);
 
         run.updateValue(this, result, input.getTime());
@@ -209,28 +210,28 @@ public class RuleSet extends Flow.Node {
 
         protected String m_media;
 
-        protected String m_flowUUID;
+        protected String m_flowUuid;
 
-        public Result(Rule rule, String value, String category, String text, String media, String flowUUID) {
+        public Result(Rule rule, String value, String category, String text, String media, String flowUuid) {
             m_rule = rule;
             m_value = value;
             m_category = category;
             m_text = text;
             m_media = media;
-            m_flowUUID = flowUUID;
+            m_flowUuid = flowUuid;
         }
 
         public static Result fromJson(JsonElement elm, Flow.DeserializationContext context) {
             JsonObject obj = elm.getAsJsonObject();
-            String flowUUID = JsonUtils.getAsString(obj, "flow_uuid");
-            Flow flow = context.getFlow(flowUUID);
+            String flowUuid = JsonUtils.getAsString(obj, "flow_uuid");
+            Flow flow = context.getFlow(flowUuid);
             return new Result(
                     (Rule) flow.getElementByUuid(obj.get("uuid").getAsString()),
                     JsonUtils.getAsString(obj, "value"),
                     JsonUtils.getAsString(obj, "category"),
                     JsonUtils.getAsString(obj, "text"),
                     JsonUtils.getAsString(obj, "media"),
-                    flowUUID
+                    flowUuid
             );
         }
 
@@ -242,7 +243,7 @@ public class RuleSet extends Flow.Node {
                     "category", m_category,
                     "text", m_text,
                     "media", m_media,
-                    "flow_uuid", m_flowUUID
+                    "flow_uuid", m_flowUuid
             );
         }
 
@@ -273,5 +274,8 @@ public class RuleSet extends Flow.Node {
             return m_media;
         }
 
+        public String getFlowUuid() {
+            return m_flowUuid;
+        }
     }
 }

--- a/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/RuleSet.java
@@ -66,12 +66,12 @@ public class RuleSet extends Flow.Node {
     /**
      * Get the id for our subflow if we have one
      */
-    public int getSubflowId() {
+    public String getSubflowUUID() {
         Object flow = m_config.get("flow");
         if (flow != null) {
-            return ((Double) ((Map)flow).get("id")).intValue();
+            return ((Map)flow).get("uuid").toString();
         }
-        return 0;
+        return null;
     }
 
     /**
@@ -119,7 +119,7 @@ public class RuleSet extends Flow.Node {
         String category = rule.getCategory().getLocalized(Collections.singletonList(run.getFlow().getBaseLanguage()), "");
 
         String valueAsStr = Conversions.toString(testResult.getValue(), context);
-        Result result = new Result(rule, valueAsStr, category, input.getValueAsText(context), input.getMedia(), step.getFlow().getId());
+        Result result = new Result(rule, valueAsStr, category, input.getValueAsText(context), input.getMedia(), step.getFlow().getUUID());
         step.setRuleResult(result);
 
         run.updateValue(this, result, input.getTime());
@@ -209,28 +209,28 @@ public class RuleSet extends Flow.Node {
 
         protected String m_media;
 
-        protected int m_flowId;
+        protected String m_flowUUID;
 
-        public Result(Rule rule, String value, String category, String text, String media, int flowId) {
+        public Result(Rule rule, String value, String category, String text, String media, String flowUUID) {
             m_rule = rule;
             m_value = value;
             m_category = category;
             m_text = text;
             m_media = media;
-            m_flowId = flowId;
+            m_flowUUID = flowUUID;
         }
 
         public static Result fromJson(JsonElement elm, Flow.DeserializationContext context) {
             JsonObject obj = elm.getAsJsonObject();
-            int flowId = JsonUtils.getAsInteger(obj, "flow_id");
-            Flow flow = context.getFlow(flowId);
+            String flowUUID = JsonUtils.getAsString(obj, "flow_uuid");
+            Flow flow = context.getFlow(flowUUID);
             return new Result(
                     (Rule) flow.getElementByUuid(obj.get("uuid").getAsString()),
                     JsonUtils.getAsString(obj, "value"),
                     JsonUtils.getAsString(obj, "category"),
                     JsonUtils.getAsString(obj, "text"),
                     JsonUtils.getAsString(obj, "media"),
-                    flowId
+                    flowUUID
             );
         }
 
@@ -242,7 +242,7 @@ public class RuleSet extends Flow.Node {
                     "category", m_category,
                     "text", m_text,
                     "media", m_media,
-                    "flow_id", m_flowId
+                    "flow_uuid", m_flowUUID
             );
         }
 

--- a/java/src/main/java/io/rapidpro/flows/definition/TranslatableText.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/TranslatableText.java
@@ -103,7 +103,7 @@ public class TranslatableText implements Jsonizable {
             preferredLanguages.add(run.getContact().getLanguage());
         }
         preferredLanguages.add(run.getOrg().getPrimaryLanguage());
-        preferredLanguages.add(run.getFlow().getBaseLanguage());
+        preferredLanguages.add(run.getActiveFlow().getBaseLanguage());
 
         return getLocalized(preferredLanguages, defaultText);
     }

--- a/java/src/main/java/io/rapidpro/flows/definition/actions/message/MessageAction.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/actions/message/MessageAction.java
@@ -38,4 +38,8 @@ public abstract class MessageAction extends Action {
     public TranslatableText getMsg() {
         return m_msg;
     }
+
+    public String toString() {
+        return m_msg.toString();
+    }
 }

--- a/java/src/main/java/io/rapidpro/flows/definition/actions/message/ReplyAction.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/actions/message/ReplyAction.java
@@ -41,7 +41,6 @@ public class ReplyAction extends MessageAction {
     @Override
     protected Result executeWithMessage(Runner runner, EvaluationContext context, String message) {
         EvaluatedTemplate template = runner.substituteVariables(message, context);
-
         Action performed = new ReplyAction(new TranslatableText(template.getOutput()));
         return Result.performed(performed, template.getErrors());
     }

--- a/java/src/main/java/io/rapidpro/flows/definition/tests/SubflowTest.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/tests/SubflowTest.java
@@ -1,0 +1,40 @@
+package io.rapidpro.flows.definition.tests;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.rapidpro.expressions.EvaluationContext;
+import io.rapidpro.flows.definition.Flow;
+import io.rapidpro.flows.definition.FlowParseException;
+import io.rapidpro.flows.runner.RunState;
+import io.rapidpro.flows.runner.Runner;
+import io.rapidpro.flows.utils.JsonUtils;
+
+/**
+ * Test that evaulates the exit of a subflow. In our case, we always
+ */
+public class SubflowTest extends Test {
+
+    public static final String TYPE = "subflow";
+    public static final String EXIT_TYPE = "exit_type";
+
+    private String m_exitType;
+
+    public SubflowTest(String exitType) {
+        m_exitType = exitType;
+    }
+
+    @Override
+    public Result evaluate(Runner runner, RunState run, EvaluationContext context, String text) {
+        return Result.match(text);
+    }
+
+    public static SubflowTest fromJson(JsonElement elm, Flow.DeserializationContext context) throws FlowParseException {
+        JsonObject obj = elm.getAsJsonObject();
+        return new SubflowTest(obj.get(EXIT_TYPE).getAsString());
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return JsonUtils.object("type", TYPE, EXIT_TYPE, m_exitType);
+    }
+}

--- a/java/src/main/java/io/rapidpro/flows/definition/tests/SubflowTest.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/tests/SubflowTest.java
@@ -10,7 +10,7 @@ import io.rapidpro.flows.runner.Runner;
 import io.rapidpro.flows.utils.JsonUtils;
 
 /**
- * Test that evaulates the exit of a subflow. In our case, we always
+ * Test that evaulates the exit of a subflow.
  */
 public class SubflowTest extends Test {
 

--- a/java/src/main/java/io/rapidpro/flows/definition/tests/Test.java
+++ b/java/src/main/java/io/rapidpro/flows/definition/tests/Test.java
@@ -61,6 +61,7 @@ public abstract class Test implements Jsonizable {
         s_classByType.put(HasStateTest.TYPE, HasStateTest.class);
         s_classByType.put(HasDistrictTest.TYPE, HasDistrictTest.class);
         s_classByType.put(HasWardTest.TYPE, HasWardTest.class);
+        s_classByType.put(SubflowTest.TYPE, SubflowTest.class);
     }
 
     /**

--- a/java/src/main/java/io/rapidpro/flows/runner/RunState.java
+++ b/java/src/main/java/io/rapidpro/flows/runner/RunState.java
@@ -54,7 +54,7 @@ public class RunState implements Jsonizable {
 
     protected Map<String,Flow> m_flows;
 
-    protected List<String> m_activeFlowUUIDs;
+    protected List<String> m_activeFlowUuids;
 
     protected List<Step> m_suspendedSteps;
 
@@ -76,7 +76,7 @@ public class RunState implements Jsonizable {
         this.m_state = State.IN_PROGRESS;
         this.m_flows = flows;
         this.m_level = 0;
-        this.m_activeFlowUUIDs = new ArrayList<>();
+        this.m_activeFlowUuids = new ArrayList<>();
         this.m_suspendedSteps = new ArrayList<>();
 
         // our current level of values
@@ -86,7 +86,7 @@ public class RunState implements Jsonizable {
 
     public static Map<String,Flow> buildFlowMap(Flow flow) {
         Map<String,Flow> flows = new HashMap<>();
-        flows.put(flow.getUUID(), flow);
+        flows.put(flow.getUuid(), flow);
         return flows;
     }
 
@@ -114,7 +114,7 @@ public class RunState implements Jsonizable {
         run.m_state = State.valueOf(obj.get("state").getAsString().toUpperCase());
         run.m_level = obj.get("level").getAsInt();
         run.m_suspendedSteps = JsonUtils.fromJsonArray(obj.get("suspended_steps").getAsJsonArray(), context, Step.class);
-        run.m_activeFlowUUIDs = JsonUtils.fromJsonArray(obj.get("active_flows").getAsJsonArray(), null, String.class);
+        run.m_activeFlowUuids = JsonUtils.fromJsonArray(obj.get("active_flows").getAsJsonArray(), null, String.class);
 
         return run;
     }
@@ -134,7 +134,7 @@ public class RunState implements Jsonizable {
                 "values", toJsonObjectArray(m_values),
                 "extra", JsonUtils.toJsonObject(m_extra),
                 "state", m_state.name().toLowerCase(),
-                "active_flows", JsonUtils.toJsonArray(m_activeFlowUUIDs),
+                "active_flows", JsonUtils.toJsonArray(m_activeFlowUuids),
                 "suspended_steps", JsonUtils.toJsonArray(m_suspendedSteps),
                 "level", m_level
         );
@@ -161,10 +161,10 @@ public class RunState implements Jsonizable {
 
     /**
      * Sets the active flow by pushing on to our list of flows
-     * @param activeFlowUUID
+     * @param activeFlowUuid
      */
-    public void setActiveFlow(String activeFlowUUID) {
-        this.m_activeFlowUUIDs.add(activeFlowUUID);
+    public void setActiveFlow(String activeFlowUuid) {
+        this.m_activeFlowUuids.add(activeFlowUuid);
     }
 
     /**
@@ -231,12 +231,12 @@ public class RunState implements Jsonizable {
      * Enters a subflow. Suspends the current step and pushes the provided
      * flow on to our active flow list.
      * @param currentStep the step to suspend until completion of the subflow
-     * @param flowUUID the flow start
+     * @param flowUuid the flow start
      */
-    public void enterSubflow(Step currentStep, String flowUUID) {
+    public void enterSubflow(Step currentStep, String flowUuid) {
         m_level++;
         m_suspendedSteps.add(currentStep);
-        setActiveFlow(flowUUID);
+        setActiveFlow(flowUuid);
 
         // wipe any existing values at our new level
         getValues().clear();
@@ -249,7 +249,7 @@ public class RunState implements Jsonizable {
      */
     public Step exitSubflow() {
         m_level--;
-        m_activeFlowUUIDs.remove(m_activeFlowUUIDs.size() - 1);
+        m_activeFlowUuids.remove(m_activeFlowUuids.size() - 1);
         return m_suspendedSteps.remove(m_suspendedSteps.size() - 1);
     }
 
@@ -323,11 +323,11 @@ public class RunState implements Jsonizable {
     }
 
     public Flow getFlow() {
-        return m_flows.get(getActiveFlowUUID());
+        return m_flows.get(getActiveFlowUuid());
     }
 
-    public String getActiveFlowUUID() {
-        return m_activeFlowUUIDs.get(m_activeFlowUUIDs.size() - 1);
+    public String getActiveFlowUuid() {
+        return m_activeFlowUuids.get(m_activeFlowUuids.size() - 1);
     }
 
     public Instant getStarted() {
@@ -345,7 +345,7 @@ public class RunState implements Jsonizable {
     public List<Step> getCompletedSteps() {
         List<Step> completed = new ArrayList<>();
         for (Step step : m_steps) {
-            if (step.isCompleted() || m_state == State.COMPLETED) {
+            if (step.isCompleted()) {
                 completed.add(step);
             }
         }

--- a/java/src/main/java/io/rapidpro/flows/runner/RunState.java
+++ b/java/src/main/java/io/rapidpro/flows/runner/RunState.java
@@ -1,5 +1,6 @@
 package io.rapidpro.flows.runner;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.rapidpro.expressions.EvaluationContext;
@@ -16,15 +17,14 @@ import org.threeten.bp.LocalDate;
 import org.threeten.bp.ZonedDateTime;
 import org.threeten.bp.temporal.ChronoUnit;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Represents state of a flow run after visiting one or more nodes in the flow
  */
 public class RunState implements Jsonizable {
+
+
 
     public enum State {
         IN_PROGRESS,
@@ -46,55 +46,76 @@ public class RunState implements Jsonizable {
 
     protected List<Step> m_steps;
 
-    protected Map<String, Value> m_values;
+    protected List<Map<String, Value>> m_values;
 
     protected Map<String, String> m_extra;
 
     protected State m_state;
 
-    protected Flow m_flow;
+    protected Map<Integer,Flow> m_flows;
+
+    protected List<Integer> m_activeFlowIds;
+
+    protected List<Step> m_suspendedSteps;
+
+    protected int m_level;
 
     /**
      * Creates a run state for a new run by the given contact in the given flow
      * @param org the org
      * @param fields the contact fields
      * @param contact the contact
-     * @param flow the flow
      */
-    public RunState(Org org, List<Field> fields, Contact contact, Flow flow) {
+    public RunState(Org org, List<Field> fields, Contact contact, Map<Integer,Flow> flows) {
         this.m_org = org;
         this.m_fields = fields;
         this.m_contact = contact;
         this.m_started = Instant.now();
         this.m_steps = new ArrayList<>();
-        this.m_values = new HashMap<>();
         this.m_extra = new HashMap<>();
         this.m_state = State.IN_PROGRESS;
-        this.m_flow = flow;
+        this.m_flows = flows;
+        this.m_level = 0;
+        this.m_activeFlowIds = new ArrayList<>();
+        this.m_suspendedSteps = new ArrayList<>();
+
+        // our current level of values
+        this.m_values = new ArrayList<>();
+        this.m_values.add(new HashMap<String, Value>());
+    }
+
+    public static Map<Integer,Flow> buildFlowMap(Flow flow) {
+        Map<Integer,Flow> flows = new HashMap<>();
+        flows.put(flow.getId(), flow);
+        return flows;
     }
 
     /**
      * Restores a run state from JSON
      * @param json the JSON containing a serialized run state
-     * @param flow the flow the run state is for
+     * @param flows the flows the run state is for
      * @return the run state
      */
-    public static RunState fromJson(String json, Flow flow) {
+    public static RunState fromJson(String json, Map<Integer,Flow> flows) {
         JsonObject obj = JsonUtils.getGson().fromJson(json, JsonObject.class);
-        Flow.DeserializationContext context = new Flow.DeserializationContext(flow);
+        Flow.DeserializationContext context = new Flow.DeserializationContext(flows);
 
         RunState run = new RunState(
                 Org.fromJson(obj.get("org")),
                 JsonUtils.fromJsonArray(obj.get("fields").getAsJsonArray(), null, Field.class),
                 Contact.fromJson(obj.get("contact")),
-                flow
+                flows
         );
 
         run.m_started = ExpressionUtils.parseJsonDate(JsonUtils.getAsString(obj, "started"));
         run.m_steps = JsonUtils.fromJsonArray(obj.get("steps").getAsJsonArray(), context, Step.class);
-        run.m_values = JsonUtils.fromJsonObject(obj.get("values").getAsJsonObject(), null, Value.class);
+        run.m_values = JsonUtils.fromJsonObjectArray(obj.get("values").getAsJsonArray(), null, Value.class);
         run.m_extra = JsonUtils.fromJsonObject(obj.get("extra").getAsJsonObject(), null, String.class);
         run.m_state = State.valueOf(obj.get("state").getAsString().toUpperCase());
+        run.m_level = obj.get("level").getAsInt();
+        run.m_suspendedSteps = JsonUtils.fromJsonArray(obj.get("suspended_steps").getAsJsonArray(), context, Step.class);
+        run.m_activeFlowIds = JsonUtils.fromJsonArray(obj.get("active_flows").getAsJsonArray(), null, Integer.class);
+
         return run;
     }
 
@@ -110,10 +131,24 @@ public class RunState implements Jsonizable {
                 "contact", m_contact.toJson(),
                 "started", ExpressionUtils.formatJsonDate(m_started),
                 "steps", JsonUtils.toJsonArray(m_steps),
-                "values", JsonUtils.toJsonObject(m_values),
+                "values", toJsonObjectArray(m_values),
                 "extra", JsonUtils.toJsonObject(m_extra),
-                "state", m_state.name().toLowerCase()
+                "state", m_state.name().toLowerCase(),
+                "active_flows", JsonUtils.toJsonArray(m_activeFlowIds),
+                "suspended_steps", JsonUtils.toJsonArray(m_suspendedSteps),
+                "level", m_level
         );
+    }
+
+    /**
+     * Helper to write out our list of value maps as JSON
+     */
+    private JsonArray toJsonObjectArray(Iterable<Map<String, Value>> values) {
+        JsonArray arr = new JsonArray();
+        for (Map<String, ?> item : values) {
+            arr.add(JsonUtils.toJsonObject(item));
+        }
+        return arr;
     }
 
     /**
@@ -122,6 +157,14 @@ public class RunState implements Jsonizable {
      */
     public String toJsonString() {
         return JsonUtils.getGson().toJson(toJson());
+    }
+
+    /**
+     * Sets the active flow by pushing on to our list of flows
+     * @param activeFlow
+     */
+    public void setActiveFlow(int activeFlow) {
+        this.m_activeFlowIds.add(activeFlow);
     }
 
     /**
@@ -144,18 +187,33 @@ public class RunState implements Jsonizable {
         context.putVariable("date", buildDateContext(context));
         context.putVariable("contact", contactContext);
         context.putVariable("extra", m_extra);
+        context.putVariable("flow", buildFlowContext(getValues(), context));
 
+        // add the flow that was one level above us
+        if (m_level > 0) {
+            context.putVariable("parent", buildFlowContext(m_values.get(m_level - 1), context));
+        }
+
+        // if we have a child below us, add that context in too
+        if (m_values.size() > m_level + 1) {
+            context.putVariable("child", buildFlowContext(m_values.get(m_level + 1), context));
+        }
+
+        return context;
+    }
+
+    /**
+     * Builds up a flow context from a set of flow values
+     */
+    private Map<String,Object> buildFlowContext(Map<String,Value> flowValues, EvaluationContext context) {
         Map<String, Object> flowContext = new HashMap<>();
         List<String> values = new ArrayList<>();
-        for (Map.Entry<String, Value> entry : m_values.entrySet()) {
+        for (Map.Entry<String, Value> entry : flowValues.entrySet()) {
             flowContext.put(entry.getKey(), entry.getValue().buildContext(context));
             values.add(entry.getKey() + ": " + entry.getValue().getValue());
         }
         flowContext.put("*", StringUtils.join(values, "\n"));
-
-        context.putVariable("flow", flowContext);
-
-        return context;
+        return flowContext;
     }
 
     /**
@@ -166,8 +224,33 @@ public class RunState implements Jsonizable {
      */
     public void updateValue(RuleSet ruleSet, RuleSet.Result result, Instant time) {
         String key = ruleSet.getLabel().toLowerCase().replaceAll("[^a-z0-9]+", "_");
+        getValues().put(key, new Value(result.getValue(), result.getCategory(), result.getText(), time));
+    }
 
-        m_values.put(key, new Value(result.getValue(), result.getCategory(), result.getText(), time));
+    /**
+     * Enters a subflow. Suspends the current step and pushes the provided
+     * flow on to our active flow list.
+     * @param currentStep the step to suspend until completion of the subflow
+     * @param flowId the flow start
+     */
+    public void enterSubflow(Step currentStep, int flowId) {
+        m_level++;
+        m_suspendedSteps.add(currentStep);
+        setActiveFlow(flowId);
+
+        // wipe any existing values at our new level
+        getValues().clear();
+
+    }
+
+    /**
+     * Exits our current subflow, going back to the parent.
+     * @return the most recently suspended step
+     */
+    public Step exitSubflow() {
+        m_level--;
+        m_activeFlowIds.remove(m_activeFlowIds.size() - 1);
+        return m_suspendedSteps.remove(m_suspendedSteps.size() - 1);
     }
 
     /**
@@ -240,7 +323,11 @@ public class RunState implements Jsonizable {
     }
 
     public Flow getFlow() {
-        return m_flow;
+        return m_flows.get(getActiveFlowId());
+    }
+
+    public int getActiveFlowId() {
+        return m_activeFlowIds.get(m_activeFlowIds.size() - 1);
     }
 
     public Instant getStarted() {
@@ -265,8 +352,25 @@ public class RunState implements Jsonizable {
         return completed;
     }
 
+    public void clearCompletedSteps() {
+        List<Step> incomplete = new ArrayList<>();
+        for (Step step : m_steps) {
+            if (!step.isCompleted() && m_state != State.COMPLETED) {
+                incomplete.add(step);
+            }
+        }
+        m_steps = incomplete;
+    }
+
+
+    /**
+     * Get the values at the current flow level
+     */
     public Map<String, Value> getValues() {
-        return m_values;
+        while (m_values.size() <= m_level) {
+            m_values.add(new HashMap<String, Value>());
+        }
+        return m_values.get(m_level);
     }
 
     public Map<String, String> getExtra() {

--- a/java/src/main/java/io/rapidpro/flows/runner/Runner.java
+++ b/java/src/main/java/io/rapidpro/flows/runner/Runner.java
@@ -123,7 +123,6 @@ public class Runner {
                     currentNode = run.getFlow().getEntry();
 
                     // create our new step accordingly
-                    System.out.println("New step for subflow: " + run.getFlow().getMetadata().get("name"));
                     step = new Step(run.getFlow(), currentNode, arrivedOn);
                     run.getSteps().add(step);
                 }

--- a/java/src/main/java/io/rapidpro/flows/runner/Runner.java
+++ b/java/src/main/java/io/rapidpro/flows/runner/Runner.java
@@ -21,7 +21,7 @@ public class Runner {
 
     protected Instant m_now;
 
-    protected Map<Integer,Flow> m_flows;
+    protected Map<String,Flow> m_flows;
 
     public Runner(Evaluator templateEvaluator, Location.Resolver locationResolver, Instant now, List<Flow> flows) {
         m_templateEvaluator = templateEvaluator;
@@ -31,7 +31,7 @@ public class Runner {
         // create a map of flow uuid to flow
         m_flows = new HashMap<>();
         for (Flow flow : flows) {
-            m_flows.put(flow.getMetadata().get("id").getAsInt(), flow);
+            m_flows.put(flow.getUUID(), flow);
         }
     }
 
@@ -43,9 +43,9 @@ public class Runner {
      * @param flowId the id of the flow to start
      * @return the run state
      */
-    public RunState start(Org org, List<Field> fields, Contact contact, int flowId) throws FlowRunException {
+    public RunState start(Org org, List<Field> fields, Contact contact, String flowUUID) throws FlowRunException {
         RunState run = new RunState(org, fields, contact, m_flows);
-        run.setActiveFlow(flowId);
+        run.setActiveFlow(flowUUID);
         return resume(run, null);
     }
 
@@ -58,8 +58,8 @@ public class Runner {
      * @return the run state
      */
     public RunState start(Org org, List<Field> fields, Contact contact, Flow flow) throws FlowRunException {
-        m_flows.put(flow.getId(), flow);
-        return start(org, fields, contact, flow.getId());
+        m_flows.put(flow.getUUID(), flow);
+        return start(org, fields, contact, flow.getUUID());
     }
 
     /**
@@ -119,7 +119,7 @@ public class Runner {
             if (currentNode instanceof RuleSet) {
                 RuleSet ruleset = (RuleSet) currentNode;
                 if (resumeStep == null && ruleset.isSubflow() && (lastStep == null || !ruleset.getUuid().equals(lastStep.getNode().getUuid()))) {
-                    run.enterSubflow(step, ruleset.getSubflowId());
+                    run.enterSubflow(step, ruleset.getSubflowUUID());
                     currentNode = run.getFlow().getEntry();
                 }
             }

--- a/java/src/main/java/io/rapidpro/flows/runner/Runner.java
+++ b/java/src/main/java/io/rapidpro/flows/runner/Runner.java
@@ -31,7 +31,7 @@ public class Runner {
         // create a map of flow uuid to flow
         m_flows = new HashMap<>();
         for (Flow flow : flows) {
-            m_flows.put(flow.getUUID(), flow);
+            m_flows.put(flow.getUuid(), flow);
         }
     }
 
@@ -40,12 +40,12 @@ public class Runner {
      * @param org the org
      * @param fields the contact fields
      * @param contact the contact
-     * @param flowId the id of the flow to start
+     * @param flowUuid the id of the flow to start
      * @return the run state
      */
-    public RunState start(Org org, List<Field> fields, Contact contact, String flowUUID) throws FlowRunException {
+    public RunState start(Org org, List<Field> fields, Contact contact, String flowUuid) throws FlowRunException {
         RunState run = new RunState(org, fields, contact, m_flows);
-        run.setActiveFlow(flowUUID);
+        run.setActiveFlow(flowUuid);
         return resume(run, null);
     }
 
@@ -58,8 +58,8 @@ public class Runner {
      * @return the run state
      */
     public RunState start(Org org, List<Field> fields, Contact contact, Flow flow) throws FlowRunException {
-        m_flows.put(flow.getUUID(), flow);
-        return start(org, fields, contact, flow.getUUID());
+        m_flows.put(flow.getUuid(), flow);
+        return start(org, fields, contact, flow.getUuid());
     }
 
     /**
@@ -119,8 +119,13 @@ public class Runner {
             if (currentNode instanceof RuleSet) {
                 RuleSet ruleset = (RuleSet) currentNode;
                 if (resumeStep == null && ruleset.isSubflow() && (lastStep == null || !ruleset.getUuid().equals(lastStep.getNode().getUuid()))) {
-                    run.enterSubflow(step, ruleset.getSubflowUUID());
+                    run.enterSubflow(step, ruleset.getSubflowUuid());
                     currentNode = run.getFlow().getEntry();
+
+                    // create our new step accordingly
+                    System.out.println("New step for subflow: " + run.getFlow().getMetadata().get("name"));
+                    step = new Step(run.getFlow(), currentNode, arrivedOn);
+                    run.getSteps().add(step);
                 }
             }
 
@@ -162,6 +167,8 @@ public class Runner {
             }
             // if not then we've completed this flow
             else {
+
+                step.setTerminal(true);
 
                 // if its at the lowest level, then we are done
                 if (run.m_level == 0) {

--- a/java/src/main/java/io/rapidpro/flows/runner/Runner.java
+++ b/java/src/main/java/io/rapidpro/flows/runner/Runner.java
@@ -45,7 +45,7 @@ public class Runner {
      */
     public RunState start(Org org, List<Field> fields, Contact contact, String flowUuid) throws FlowRunException {
         RunState run = new RunState(org, fields, contact, m_flows);
-        run.setActiveFlow(flowUuid);
+        run.setActiveFlow(m_flows.get(flowUuid));
         return resume(run, null);
     }
 
@@ -83,7 +83,7 @@ public class Runner {
             currentNode = lastStep.getNode(); // we're resuming an existing run
         }
         else {
-            currentNode = run.getFlow().getEntry();  // we're starting a new run
+            currentNode = run.getActiveFlow().getEntry();  // we're starting a new run
             if (currentNode == null) {
                 throw new FlowRunException("Flow has no entry point");
             }
@@ -103,7 +103,7 @@ public class Runner {
             }
 
             // create our step for the current node
-            Step step = new Step(run.getFlow(), currentNode, arrivedOn);
+            Step step = new Step(run.getActiveFlow(), currentNode, arrivedOn);
 
             // if we are resuming an old step, use that instead
             if (resumeStep != null) {
@@ -120,10 +120,10 @@ public class Runner {
                 RuleSet ruleset = (RuleSet) currentNode;
                 if (resumeStep == null && ruleset.isSubflow() && (lastStep == null || !ruleset.getUuid().equals(lastStep.getNode().getUuid()))) {
                     run.enterSubflow(step, ruleset.getSubflowUuid());
-                    currentNode = run.getFlow().getEntry();
+                    currentNode = run.getActiveFlow().getEntry();
 
                     // create our new step accordingly
-                    step = new Step(run.getFlow(), currentNode, arrivedOn);
+                    step = new Step(run.getActiveFlow(), currentNode, arrivedOn);
                     run.getSteps().add(step);
                 }
             }

--- a/java/src/main/java/io/rapidpro/flows/runner/Step.java
+++ b/java/src/main/java/io/rapidpro/flows/runner/Step.java
@@ -53,7 +53,7 @@ public class Step implements Jsonizable {
     public static Step fromJson(JsonElement elm, Flow.DeserializationContext context) {
         JsonObject obj = elm.getAsJsonObject();
 
-        Flow flow = context.getFlow(obj.get("flow_id").getAsInt());
+        Flow flow = context.getFlow(obj.get("flow_uuid").getAsString());
         return new Step(flow,
                 (Flow.Node) flow.getElementByUuid(obj.get("node").getAsString()),
                 ExpressionUtils.parseJsonDate(JsonUtils.getAsString(obj, "arrived_on")),
@@ -73,7 +73,7 @@ public class Step implements Jsonizable {
                 "rule", m_ruleResult != null ? m_ruleResult.toJson() : null,
                 "actions", JsonUtils.toJsonArray(m_actions),
                 "errors", JsonUtils.toJsonArray(m_errors),
-                "flow_id", m_flow.getId()
+                "flow_uuid", m_flow.getUUID()
         );
     }
 

--- a/java/src/main/java/io/rapidpro/flows/runner/Step.java
+++ b/java/src/main/java/io/rapidpro/flows/runner/Step.java
@@ -30,26 +30,32 @@ public class Step implements Jsonizable {
 
     protected List<String> m_errors;
 
-    public Step(Flow.Node node, Instant arrivedOn) {
+    protected Flow m_flow;
+
+    public Step(Flow flow, Flow.Node node, Instant arrivedOn) {
         m_node = node;
         m_arrivedOn = arrivedOn;
         m_actions = new ArrayList<>();
         m_errors = new ArrayList<>();
+        m_flow = flow;
     }
 
-    public Step(Flow.Node node, Instant arrivedOn, Instant leftOn, RuleSet.Result ruleResult, List<Action> actions, List<String> errors) {
+    public Step(Flow flow, Flow.Node node, Instant arrivedOn, Instant leftOn, RuleSet.Result ruleResult, List<Action> actions, List<String> errors) {
         m_node = node;
         m_arrivedOn = arrivedOn;
         m_leftOn = leftOn;
         m_ruleResult = ruleResult;
         m_actions = actions;
         m_errors = errors;
+        m_flow = flow;
     }
 
     public static Step fromJson(JsonElement elm, Flow.DeserializationContext context) {
         JsonObject obj = elm.getAsJsonObject();
-        return new Step(
-                (Flow.Node) context.getFlow().getElementByUuid(obj.get("node").getAsString()),
+
+        Flow flow = context.getFlow(obj.get("flow_id").getAsInt());
+        return new Step(flow,
+                (Flow.Node) flow.getElementByUuid(obj.get("node").getAsString()),
                 ExpressionUtils.parseJsonDate(JsonUtils.getAsString(obj, "arrived_on")),
                 ExpressionUtils.parseJsonDate(JsonUtils.getAsString(obj, "left_on")),
                 JsonUtils.fromJson(obj.get("rule"), context, RuleSet.Result.class),
@@ -66,7 +72,8 @@ public class Step implements Jsonizable {
                 "left_on", ExpressionUtils.formatJsonDate(m_leftOn),
                 "rule", m_ruleResult != null ? m_ruleResult.toJson() : null,
                 "actions", JsonUtils.toJsonArray(m_actions),
-                "errors", JsonUtils.toJsonArray(m_errors)
+                "errors", JsonUtils.toJsonArray(m_errors),
+                "flow_id", m_flow.getId()
         );
     }
 
@@ -107,6 +114,10 @@ public class Step implements Jsonizable {
         }
     }
 
+    public Flow getFlow() {
+        return m_flow;
+    }
+
     public List<String> getErrors() {
         return m_errors;
     }
@@ -114,4 +125,5 @@ public class Step implements Jsonizable {
     public boolean isCompleted() {
         return m_leftOn != null;
     }
+
 }

--- a/java/src/main/java/io/rapidpro/flows/runner/Step.java
+++ b/java/src/main/java/io/rapidpro/flows/runner/Step.java
@@ -24,6 +24,8 @@ public class Step implements Jsonizable {
 
     protected Instant m_leftOn;
 
+    protected boolean m_terminal;
+
     protected RuleSet.Result m_ruleResult;
 
     protected List<Action> m_actions;
@@ -73,7 +75,7 @@ public class Step implements Jsonizable {
                 "rule", m_ruleResult != null ? m_ruleResult.toJson() : null,
                 "actions", JsonUtils.toJsonArray(m_actions),
                 "errors", JsonUtils.toJsonArray(m_errors),
-                "flow_uuid", m_flow.getUUID()
+                "flow_uuid", m_flow.getUuid()
         );
     }
 
@@ -123,7 +125,12 @@ public class Step implements Jsonizable {
     }
 
     public boolean isCompleted() {
-        return m_leftOn != null;
+        return m_leftOn != null || m_terminal;
+    }
+
+
+    public void setTerminal(boolean terminal) {
+        m_terminal = terminal;
     }
 
 }

--- a/java/src/main/java/io/rapidpro/flows/utils/JsonUtils.java
+++ b/java/src/main/java/io/rapidpro/flows/utils/JsonUtils.java
@@ -129,6 +129,8 @@ public class JsonUtils {
             return (T) elm.getAsString();
         } else if (clazz.equals(Boolean.class)) {
             return (T) (Boolean) elm.getAsBoolean();
+        } else if (clazz.equals(Integer.class)) {
+            return (T) (Integer) elm.getAsInt();
         }
 
         try {
@@ -159,4 +161,13 @@ public class JsonUtils {
         }
         return map;
     }
+
+    public static <V> List<Map<String, V>> fromJsonObjectArray(JsonArray arr, Flow.DeserializationContext context, Class<V> clazz) {
+        List<Map<String, V>> items = new ArrayList<>();
+        for (JsonElement elm : arr) {
+            items.add(fromJsonObject(elm.getAsJsonObject(), context, clazz));
+        }
+        return items;
+    }
+
 }

--- a/java/src/test/java/io/rapidpro/flows/RunnerBuilderTest.java
+++ b/java/src/test/java/io/rapidpro/flows/RunnerBuilderTest.java
@@ -2,9 +2,13 @@ package io.rapidpro.flows;
 
 import io.rapidpro.expressions.EvaluatorBuilder;
 import io.rapidpro.expressions.evaluator.Evaluator;
+import io.rapidpro.flows.definition.Flow;
 import io.rapidpro.flows.runner.Location;
 import io.rapidpro.flows.runner.Runner;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -17,7 +21,9 @@ public class RunnerBuilderTest extends BaseFlowsTest {
 
     @Test
     public void build() {
-        Runner runner = new RunnerBuilder().build();
+
+        List<Flow> flows = new ArrayList<Flow>();
+        Runner runner = new RunnerBuilder(flows).build();
         assertThat(runner.getTemplateEvaluator(), is(notNullValue()));
 
         Evaluator evaluator = new EvaluatorBuilder().build();
@@ -29,7 +35,7 @@ public class RunnerBuilderTest extends BaseFlowsTest {
             }
         };
 
-        runner = new RunnerBuilder()
+        runner = new RunnerBuilder(flows)
                 .withTemplateEvaluator(evaluator)
                 .withLocationResolver(resolver)
                 .build();

--- a/java/src/test/java/io/rapidpro/flows/runner/RunStateTest.java
+++ b/java/src/test/java/io/rapidpro/flows/runner/RunStateTest.java
@@ -57,7 +57,7 @@ public class RunStateTest extends BaseFlowsTest {
 
         // export to json and reimport
         String json = run.toJsonString();
-        RunState restored = RunState.fromJson(json, flow);
+        RunState restored = RunState.fromJson(json, RunState.buildFlowMap(flow));
 
         // json should be the same
         assertThat(restored.toJsonString(), is(json));

--- a/java/src/test/java/io/rapidpro/flows/runner/StepTest.java
+++ b/java/src/test/java/io/rapidpro/flows/runner/StepTest.java
@@ -70,7 +70,7 @@ public class StepTest extends BaseFlowsTest {
 
         Rule yesRule = ((RuleSet) ((ActionSet) flow.getEntry()).getDestination()).getRules().get(0);
 
-        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", "yes ok", null, flow.getUUID()));
+        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", "yes ok", null, flow.getUuid()));
         obj = (JsonObject) step.toJson();
 
         assertThat(obj, is(JsonUtils.object(
@@ -94,7 +94,7 @@ public class StepTest extends BaseFlowsTest {
         step.getActions().clear();
         step.getErrors().clear();
 
-        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", null, "image/png:file://var/blah.png", flow.getUUID()));
+        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", null, "image/png:file://var/blah.png", flow.getUuid()));
         obj = (JsonObject) step.toJson();
         assertThat(obj, is(JsonUtils.object(
                 "node", "32cf414b-35e3-4c75-8a78-d5f4de925e13",

--- a/java/src/test/java/io/rapidpro/flows/runner/StepTest.java
+++ b/java/src/test/java/io/rapidpro/flows/runner/StepTest.java
@@ -25,7 +25,7 @@ public class StepTest extends BaseFlowsTest {
     public void toAndFromJson() throws Exception {
         Flow flow = Flow.fromJson(readResource("test_flows/mushrooms.json"));
         Instant arrivedOn = Instant.from(ZonedDateTime.of(2015, 8, 25, 11, 59, 30, 88 * 1000000, ZoneId.of("UTC")));
-        Step step = new Step(flow.getEntry(), arrivedOn);
+        Step step = new Step(flow, flow.getEntry(), arrivedOn);
 
         JsonObject obj = (JsonObject) step.toJson();
 
@@ -35,7 +35,8 @@ public class StepTest extends BaseFlowsTest {
                 "left_on", null,
                 "rule", null,
                 "actions", JsonUtils.array(),
-                "errors", JsonUtils.array()
+                "errors", JsonUtils.array(),
+                "flow_id", 17576
         )));
 
         step.addActionResult(Action.Result.performed(new ReplyAction(new TranslatableText("Hi Joe"))));
@@ -47,7 +48,8 @@ public class StepTest extends BaseFlowsTest {
                 "left_on", null,
                 "rule", null,
                 "actions", JsonUtils.array(JsonUtils.object("type", "reply", "msg", "Hi Joe")),
-                "errors", JsonUtils.array()
+                "errors", JsonUtils.array(),
+                "flow_id", 17576
         )));
 
         step.addActionResult(Action.Result.performed(null, Arrays.asList("This is an error", "This too")));
@@ -59,7 +61,8 @@ public class StepTest extends BaseFlowsTest {
                 "left_on", null,
                 "rule", null,
                 "actions", JsonUtils.array(JsonUtils.object("type", "reply", "msg", "Hi Joe")),
-                "errors", JsonUtils.array("This is an error", "This too")
+                "errors", JsonUtils.array("This is an error", "This too"),
+                "flow_id", 17576
         )));
 
         step.getActions().clear();
@@ -67,7 +70,7 @@ public class StepTest extends BaseFlowsTest {
 
         Rule yesRule = ((RuleSet) ((ActionSet) flow.getEntry()).getDestination()).getRules().get(0);
 
-        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", "yes ok", null));
+        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", "yes ok", null, flow.getId()));
         obj = (JsonObject) step.toJson();
 
         assertThat(obj, is(JsonUtils.object(
@@ -79,17 +82,19 @@ public class StepTest extends BaseFlowsTest {
                         "value", "yes",
                         "category", "Yes",
                         "text", "yes ok",
-                        "media", null
+                        "media", null,
+                        "flow_id", 17576
                 ),
                 "actions", JsonUtils.array(),
-                "errors", JsonUtils.array()
+                "errors", JsonUtils.array(),
+                "flow_id", 17576
         )));
 
         // test to and from with media value
         step.getActions().clear();
         step.getErrors().clear();
 
-        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", null, "image/png:file://var/blah.png"));
+        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", null, "image/png:file://var/blah.png", flow.getId()));
         obj = (JsonObject) step.toJson();
         assertThat(obj, is(JsonUtils.object(
                 "node", "32cf414b-35e3-4c75-8a78-d5f4de925e13",
@@ -100,10 +105,12 @@ public class StepTest extends BaseFlowsTest {
                         "value", "yes",
                         "category", "Yes",
                         "text", null,
-                        "media", "image/png:file://var/blah.png"
+                        "media", "image/png:file://var/blah.png",
+                        "flow_id", 17576
                 ),
                 "actions", JsonUtils.array(),
-                "errors", JsonUtils.array()
+                "errors", JsonUtils.array(),
+                "flow_id", 17576
         )));
     }
 }

--- a/java/src/test/java/io/rapidpro/flows/runner/StepTest.java
+++ b/java/src/test/java/io/rapidpro/flows/runner/StepTest.java
@@ -36,7 +36,7 @@ public class StepTest extends BaseFlowsTest {
                 "rule", null,
                 "actions", JsonUtils.array(),
                 "errors", JsonUtils.array(),
-                "flow_id", 17576
+                "flow_uuid", "73c40f19-007d-46bd-83ea-aef439de9f9c"
         )));
 
         step.addActionResult(Action.Result.performed(new ReplyAction(new TranslatableText("Hi Joe"))));
@@ -49,7 +49,7 @@ public class StepTest extends BaseFlowsTest {
                 "rule", null,
                 "actions", JsonUtils.array(JsonUtils.object("type", "reply", "msg", "Hi Joe")),
                 "errors", JsonUtils.array(),
-                "flow_id", 17576
+                "flow_uuid", "73c40f19-007d-46bd-83ea-aef439de9f9c"
         )));
 
         step.addActionResult(Action.Result.performed(null, Arrays.asList("This is an error", "This too")));
@@ -62,7 +62,7 @@ public class StepTest extends BaseFlowsTest {
                 "rule", null,
                 "actions", JsonUtils.array(JsonUtils.object("type", "reply", "msg", "Hi Joe")),
                 "errors", JsonUtils.array("This is an error", "This too"),
-                "flow_id", 17576
+                "flow_uuid", "73c40f19-007d-46bd-83ea-aef439de9f9c"
         )));
 
         step.getActions().clear();
@@ -70,7 +70,7 @@ public class StepTest extends BaseFlowsTest {
 
         Rule yesRule = ((RuleSet) ((ActionSet) flow.getEntry()).getDestination()).getRules().get(0);
 
-        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", "yes ok", null, flow.getId()));
+        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", "yes ok", null, flow.getUUID()));
         obj = (JsonObject) step.toJson();
 
         assertThat(obj, is(JsonUtils.object(
@@ -83,18 +83,18 @@ public class StepTest extends BaseFlowsTest {
                         "category", "Yes",
                         "text", "yes ok",
                         "media", null,
-                        "flow_id", 17576
+                        "flow_uuid", "73c40f19-007d-46bd-83ea-aef439de9f9c"
                 ),
                 "actions", JsonUtils.array(),
                 "errors", JsonUtils.array(),
-                "flow_id", 17576
+                "flow_uuid", "73c40f19-007d-46bd-83ea-aef439de9f9c"
         )));
 
         // test to and from with media value
         step.getActions().clear();
         step.getErrors().clear();
 
-        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", null, "image/png:file://var/blah.png", flow.getId()));
+        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", null, "image/png:file://var/blah.png", flow.getUUID()));
         obj = (JsonObject) step.toJson();
         assertThat(obj, is(JsonUtils.object(
                 "node", "32cf414b-35e3-4c75-8a78-d5f4de925e13",
@@ -106,11 +106,11 @@ public class StepTest extends BaseFlowsTest {
                         "category", "Yes",
                         "text", null,
                         "media", "image/png:file://var/blah.png",
-                        "flow_id", 17576
+                        "flow_uuid", "73c40f19-007d-46bd-83ea-aef439de9f9c"
                 ),
                 "actions", JsonUtils.array(),
                 "errors", JsonUtils.array(),
-                "flow_id", 17576
+                "flow_uuid", "73c40f19-007d-46bd-83ea-aef439de9f9c"
         )));
     }
 }

--- a/java/src/test/java/io/rapidpro/flows/runner/StepTest.java
+++ b/java/src/test/java/io/rapidpro/flows/runner/StepTest.java
@@ -70,7 +70,7 @@ public class StepTest extends BaseFlowsTest {
 
         Rule yesRule = ((RuleSet) ((ActionSet) flow.getEntry()).getDestination()).getRules().get(0);
 
-        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", "yes ok", null, flow.getUuid()));
+        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", "yes ok", null, flow));
         obj = (JsonObject) step.toJson();
 
         assertThat(obj, is(JsonUtils.object(
@@ -94,7 +94,7 @@ public class StepTest extends BaseFlowsTest {
         step.getActions().clear();
         step.getErrors().clear();
 
-        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", null, "image/png:file://var/blah.png", flow.getUuid()));
+        step.setRuleResult(new RuleSet.Result(yesRule, "yes", "Yes", null, "image/png:file://var/blah.png", flow));
         obj = (JsonObject) step.toJson();
         assertThat(obj, is(JsonUtils.object(
                 "node", "32cf414b-35e3-4c75-8a78-d5f4de925e13",

--- a/java/src/test/java/io/rapidpro/flows/runner/SubflowTest.java
+++ b/java/src/test/java/io/rapidpro/flows/runner/SubflowTest.java
@@ -1,0 +1,87 @@
+package io.rapidpro.flows.runner;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.rapidpro.expressions.EvaluationContext;
+import io.rapidpro.expressions.dates.DateStyle;
+import io.rapidpro.flows.BaseFlowsTest;
+import io.rapidpro.flows.InteractionTest;
+import io.rapidpro.flows.RunnerBuilder;
+import io.rapidpro.flows.definition.Flow;
+import io.rapidpro.flows.definition.actions.Action;
+import io.rapidpro.flows.definition.actions.message.ReplyAction;
+import io.rapidpro.flows.utils.JsonUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class SubflowTest extends BaseFlowsTest {
+
+    protected Runner m_runner;
+
+    @Before
+    public void setupRunState() throws Exception {
+
+
+        String definitions = readResource("test_flows/subflow.json");
+        JsonObject obj = JsonUtils.getGson().fromJson(definitions, JsonObject.class);
+        JsonArray flowArray = obj.getAsJsonArray("flows");
+
+        List<Flow> flows = new ArrayList<>();
+        for (JsonElement ele : flowArray) {
+            flows.add(Flow.fromJson(ele.getAsJsonObject().toString()));
+        }
+
+        m_runner = new RunnerBuilder(flows).withLocationResolver(new TestLocationResolver()).build();
+    }
+
+    public List<String> getMessages(RunState run) {
+        List<String> msgs = new ArrayList<>();
+        for (Step step : run.getCompletedSteps()) {
+            for (Action action : step.getActions()) {
+                if (action instanceof ReplyAction) {
+                    String msg = ((ReplyAction) action).getMsg().getLocalized(run);
+                    msgs.add(msg);
+                }
+            }
+        }
+        return msgs;
+    }
+
+    @Test
+    public void testSubflow() throws Exception {
+
+        // start in the parent run
+        RunState run = m_runner.start(m_org, m_fields, m_contact, 35636);
+
+        // starting the flow should get us our initial prompt
+        assertThat(getMessages(run).size(), is(1));
+        assertThat(getMessages(run).get(0), is("This is a parent flow. What would you like to do?"));
+
+        // respond with "color" which should launch the color subflow
+        run = m_runner.resume(run, Input.of("color"));
+
+        // our returned RunState should be for our child flow
+        assertThat(getMessages(run).get(0), is("What color do you like?"));
+
+        // submit in our subflow which should complete it and take us to the parent
+        run = m_runner.resume(run, Input.of("red"));
+        assertThat(getMessages(run).get(0), is("Complete: You picked Red."));
+        assertThat(getMessages(run).get(1), is("This is a parent flow. What would you like to do?"));
+
+        // run our subflow a second time in the same parent
+        run = m_runner.resume(run, Input.of("color"));
+        run = m_runner.resume(run, Input.of("green"));
+        assertThat(getMessages(run).get(0), is("Complete: You picked Green."));
+
+    }
+
+}

--- a/java/src/test/java/io/rapidpro/flows/runner/SubflowTest.java
+++ b/java/src/test/java/io/rapidpro/flows/runner/SubflowTest.java
@@ -60,7 +60,7 @@ public class SubflowTest extends BaseFlowsTest {
     public void testSubflow() throws Exception {
 
         // start in the parent run
-        RunState run = m_runner.start(m_org, m_fields, m_contact, 35636);
+        RunState run = m_runner.start(m_org, m_fields, m_contact, "7c1dee9b-af4c-407b-a269-5553e59149e1");
 
         // starting the flow should get us our initial prompt
         assertThat(getMessages(run).size(), is(1));

--- a/python/temba_flows/definition/__init__.py
+++ b/python/temba_flows/definition/__init__.py
@@ -41,7 +41,7 @@ class TranslatableText(object):
             preferred_languages.append(run_state.contact.language)
 
         preferred_languages.append(run_state.org.primary_language)
-        preferred_languages.append(run_state.flow.base_language)
+        preferred_languages.append(run_state.get_flow().base_language)
 
         return self.get_localized_by_preferred(preferred_languages, default_text)
 

--- a/python/temba_flows/definition/actions.py
+++ b/python/temba_flows/definition/actions.py
@@ -103,7 +103,6 @@ class ReplyAction(MessageAction):
 
     def execute_with_message(self, runner, context, msg):
         template, errors = runner.substitute_variables(msg, context)
-
         performed = ReplyAction(TranslatableText(template))
         return Action.Result.performed(performed, errors)
 

--- a/python/temba_flows/definition/flow.py
+++ b/python/temba_flows/definition/flow.py
@@ -93,8 +93,8 @@ class Flow(object):
 
         return flow
 
-    def get_id(self):
-        return self.metadata.get('id', None)
+    def get_uuid(self):
+        return self.metadata.get('uuid', None)
 
     class DeserializationContext(object):
         """
@@ -107,8 +107,8 @@ class Flow(object):
         def needs_destination(self, start, destination_uuid):
             self.destinations_to_set[start] = destination_uuid
 
-        def get_flow(self, flow_id):
-            return self.flow_dict[flow_id]
+        def get_flow(self, flow_uuid):
+            return self.flow_dict[flow_uuid]
 
     class Element(object):
         """
@@ -273,8 +273,8 @@ class RuleSet(Flow.Node):
     def is_subflow(self):
         return self.ruleset_type == RuleSet.Type.SUBFLOW
 
-    def get_subflow_id(self):
-        return self.config.get('flow', {}).get('id', None)
+    def get_subflow_uuid(self):
+        return self.config.get('flow', {}).get('uuid', None)
 
     class Result(object):
         """
@@ -290,7 +290,7 @@ class RuleSet(Flow.Node):
 
         @classmethod
         def from_json(cls, json_obj, context):
-            flow = context.get_flow(json_obj['flow_id'])
+            flow = context.get_flow(json_obj['flow_uuid'])
             return cls(flow,
                        flow.get_element_by_uuid(json_obj['uuid']),
                        json_obj['value'],
@@ -300,7 +300,7 @@ class RuleSet(Flow.Node):
 
         def to_json(self):
             return {
-                'flow_id': self.flow.get_id(),
+                'flow_uuid': self.flow.get_uuid(),
                 'uuid': self.rule.uuid,
                 'value': self.value,
                 'category': self.category,

--- a/python/temba_flows/definition/tests.py
+++ b/python/temba_flows/definition/tests.py
@@ -46,7 +46,8 @@ class Test(object):
                 HasPhoneTest.TYPE: HasPhoneTest,
                 HasStateTest.TYPE: HasStateTest,
                 HasDistrictTest.TYPE: HasDistrictTest,
-                HasWardTest.TYPE: HasWardTest
+                HasWardTest.TYPE: HasWardTest,
+                SubflowTest.TYPE: SubflowTest
             }
 
         test_type = json_obj['type']
@@ -813,3 +814,24 @@ class HasWardTest(Test):
                             return Test.Result.match(ward.name)
 
         return Test.Result.NO_MATCH
+
+
+class SubflowTest(Test):
+    """
+    Test for evaluating the type of exit from a subflow
+    """
+    TYPE = "subflow"
+    EXIT_TYPE = "exit_type"
+
+    def __init__(self, exit_type):
+        self.exit_type = exit_type
+
+    @classmethod
+    def from_json(cls, json_obj, context):
+        return cls(json_obj.get(cls.EXIT_TYPE))
+
+    def to_json(self):
+        return {'type': self.TYPE, cls.EXIT_TYPE: self.exit_type}
+
+    def evaluate(self, runner, run, context, text):
+        return Test.Result.match(text)

--- a/python/temba_flows/runner.py
+++ b/python/temba_flows/runner.py
@@ -19,7 +19,8 @@ from .utils import normalize_number
 
 
 DEFAULT_EVALUATOR = Evaluator(expression_prefix='@',
-                              allowed_top_levels=('channel', 'contact', 'date', 'extra', 'flow', 'step'))
+                              allowed_top_levels=('channel', 'contact', 'date', 'extra',
+                                                  'flow', 'step', 'parent', 'child'))
 
 
 class Org(object):
@@ -383,7 +384,8 @@ class Step(object):
     """
     A step taken by a contact or surveyor in a flow run
     """
-    def __init__(self, node, arrived_on, left_on=None, rule_result=None, actions=None, errors=None):
+    def __init__(self, flow, node, arrived_on, left_on=None, rule_result=None, actions=None, errors=None):
+        self.flow = flow
         self.node = node
         self.arrived_on = arrived_on
         self.left_on = left_on
@@ -393,7 +395,10 @@ class Step(object):
 
     @classmethod
     def from_json(cls, json_obj, context):
-        return cls(context.flow.get_element_by_uuid(json_obj['node']),
+
+        flow = context.get_flow(json_obj['flow_id'])
+        return cls(flow,
+                   flow.get_element_by_uuid(json_obj['node']),
                    parse_json_date(json_obj['arrived_on']),
                    parse_json_date(json_obj['left_on']),
                    RuleSet.Result.from_json(json_obj['rule'], context) if json_obj.get('rule') else None,
@@ -407,8 +412,12 @@ class Step(object):
             'left_on': format_json_date(self.left_on),
             'rule': self.rule_result.to_json() if self.rule_result else None,
             'actions': [a.to_json() for a in self.actions],
-            'errors': self.errors
+            'errors': self.errors,
+            'flow_id': self.flow.get_id()
         }
+
+    def get_flow(self):
+        return self.flow
 
     def add_action_result(self, action_result):
         if action_result.performed:
@@ -465,37 +474,46 @@ class RunState(object):
         COMPLETED = 2
         WAIT_MESSAGE = 3
 
-    def __init__(self, org, fields, contact, flow):
+    def __init__(self, org, fields, contact, flow_dict):
         self.org = org
         self.fields = {f.key: f for f in fields}
         self.contact = contact
         self.started = datetime.datetime.now(tz=pytz.UTC)
         self.steps = []
-        self.values = {}
         self.extra = {}
         self.state = RunState.State.IN_PROGRESS
-        self.flow = flow
+        self.flow_dict = flow_dict
+        self.active_flows = []
+        self.suspended_steps = []
+        self.level = 0
+
+        # current level of values 
+        self.values = [dict()]
+
 
     @classmethod
-    def from_json(cls, json_obj, flow):
+    def from_json(cls, json_obj, flow_dict):
         """
         Restores a run state from JSON
         :param json_obj: the JSON containing a serialized run state
         :param flow: the flow the run state is for
         :return: the run state
         """
-        deserialization_context = Flow.DeserializationContext(flow)
+        deserialization_context = Flow.DeserializationContext(flow_dict)
 
         run = cls(Org.from_json(json_obj['org']),
                   [Field.from_json(f) for f in json_obj['fields']],
                   Contact.from_json(json_obj['contact']),
-                  flow)
+                  flow_dict)
 
         run.started = parse_json_date(json_obj['started'])
         run.steps = [Step.from_json(s, deserialization_context) for s in json_obj['steps']]
-        run.values = {k: Value.from_json(v) for k, v in json_obj['values'].iteritems()}
+        run.values = [{k: Value.from_json(v) for k, v in values.iteritems()} for values in json_obj['values']]
         run.extra = json_obj['extra']
         run.state = RunState.State[json_obj['state'].upper()]
+        run.level = json_obj['level']
+        run.suspended_steps = [Step.from_json(s, deserialization_context) for s in json_obj['suspended_steps']]
+        run.active_flows = json_obj['active_flows']
         return run
 
     def to_json(self):
@@ -508,9 +526,12 @@ class RunState(object):
             'contact': self.contact.to_json(),
             'started': format_json_date(self.started),
             'steps': [s.to_json() for s in self.steps],
-            'values': {k: v.to_json() for k, v in self.values.iteritems()},
+            'values': [{k: v.to_json() for k, v in values.iteritems()} for values in self.values],
             'extra': self.extra,
-            'state': self.state.name.lower()
+            'state': self.state.name.lower(),
+            'active_flows': [flow_id for flow_id in self.active_flows],
+            'suspended_steps': [s.to_json() for s in self.suspended_steps],
+            'level': self.level
         }
 
     def build_context(self, runner, input):
@@ -527,17 +548,53 @@ class RunState(object):
         context.put_variable("date", self.build_date_context(context))
         context.put_variable("contact", contact_context)
         context.put_variable("extra", self.extra)
+    
+        def build_flow_context(value_dict):
+            flow_context = {}
+            values = []
+            for key, value in value_dict.iteritems():
+                flow_context[key] = value.build_context(context)
+                values.append("%s: %s" % (key, value))
+            flow_context['*'] = "\n".join(values)
 
-        flow_context = {}
-        values = []
-        for key, value in self.values.iteritems():
-            flow_context[key] = value.build_context(context)
-            values.append("%s: %s" % (key, value))
-        flow_context['*'] = "\n".join(values)
+            return flow_context
 
-        context.put_variable("flow", flow_context)
+        context.put_variable("flow", build_flow_context(self.get_values()))
+
+        # add the flow that was one level above us
+        if self.level > 0:
+            context.put_variable("parent", build_flow_context(self.values[self.level - 1]))
+
+        # if we have a child below us, add that context in too
+        if len(self.values) > self.level + 1:
+            context.put_variable("child", build_flow_context(self.values[self.level + 1]))
 
         return context
+
+    def enter_subflow(self, current_step, flow_id):
+        self.level += 1
+        self.suspended_steps.append(current_step)
+        self.set_active_flow(flow_id)
+        self.get_values().clear()
+
+    def exit_subflow(self):
+        self.level -= 1
+        self.active_flows.pop()
+        return self.suspended_steps[-1]
+
+    def set_active_flow(self, flow_id):
+        self.active_flows.append(flow_id)
+
+    def get_flow(self):
+        return self.flow_dict[self.get_active_flow_id()]
+
+    def get_active_flow_id(self):
+        return self.active_flows[self.level]
+
+    def get_values(self):
+        if len(self.values) <= self.level:
+            self.values.append({})
+        return self.values[self.level]
 
     def update_value(self, rule_set, result, time):
         """
@@ -548,7 +605,7 @@ class RunState(object):
         :return:
         """
         key = regex.sub(r'[^a-z0-9]+', '_', rule_set.label.lower())
-        self.values[key] = Value(result.value, result.category, result.text, time)
+        self.get_values()[key] = Value(result.value, result.category, result.text, time)
 
     @staticmethod
     def build_date_context(container):
@@ -606,21 +663,29 @@ class Runner(object):
     """
     The flow runner
     """
-    def __init__(self, template_evaluator=DEFAULT_EVALUATOR, location_resolver=None, now=None):
+    def __init__(self, flow_list=None, template_evaluator=DEFAULT_EVALUATOR, location_resolver=None, now=None):
         self.template_evaluator = template_evaluator
         self.location_resolver = location_resolver
         self.now = now
 
-    def start(self, org, fields, contact, flow):
+        # create a map of flows we are going to run with
+        if flow_list:
+            self.flow_dict = {flow.get_id() : flow for flow in flow_list}
+        else:
+            self.flow_dict = {}
+
+    def start(self, org, fields, contact, flow_id):
         """
         Starts a new run
         :param org: the org
         :param fields: the contact fields
         :param contact: the contact
-        :param flow: the flow
+        :param flow_id: the id of the flow to start
         :return: the run state
         """
-        run = RunState(org, fields, contact, flow)
+
+        run = RunState(org, fields, contact, self.flow_dict)
+        run.set_active_flow(flow_id)
         return self.resume(run, None)
 
     def resume(self, run, input):
@@ -641,13 +706,14 @@ class Runner(object):
         if last_step:
             current_node = last_step.node  # we're resuming an existing run
         else:
-            current_node = run.flow.entry  # we're starting a new run
+            current_node = run.get_flow().entry  # we're starting a new run
             if not current_node:
                 raise FlowRunException("Flow has no entry point")
 
         # tracks nodes visited so we can detect loops
         nodes_visited = OrderedSet()
 
+        resume_step = None
         while current_node:
             # if we're resuming a previously paused step, then use its arrived on value
             if last_step and len(nodes_visited) == 0:
@@ -656,8 +722,16 @@ class Runner(object):
                 arrived_on = datetime.datetime.now(tz=pytz.UTC)
 
             # create new step for this node
-            step = Step(current_node, arrived_on)
+            step = Step(run.get_flow(), current_node, arrived_on)
             run.steps.append(step)
+
+            # see if we should dive into a subflow
+            if isinstance(current_node, RuleSet):
+                if resume_step is None and current_node.is_subflow() and (current_node.uuid != last_step.node.uuid):
+                    run.enter_subflow(step, current_node.get_subflow_id());
+                    current_node = run.get_flow().entry;
+
+            resume_step = None
 
             # should we pause at this node?
             if isinstance(current_node, RuleSet):
@@ -677,8 +751,15 @@ class Runner(object):
                 # if we have a next node, then record leaving this one
                 step.left_on = datetime.datetime.now(tz=pytz.UTC)
             else:
-                # if not then we've completed this flow
-                run.state = RunState.State.COMPLETED
+                # if we are at the lowest level, we are done
+                if run.level == 0:
+                    run.state = RunState.State.COMPLETED
+
+                # otherwise, go up a level
+                else:
+                    resume_step = run.exit_subflow()
+                    next_node = resume_step.node
+
 
             current_node = next_node
 

--- a/python/temba_flows/tests.py
+++ b/python/temba_flows/tests.py
@@ -91,7 +91,7 @@ class ActionsTest(BaseFlowsTest):
         self.deserialization_context = Flow.DeserializationContext(flow)
 
         self.runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
-        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
+        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_uuid())
         self.context = self.run.build_context(self.runner, None)
 
     def test_reply_action(self):
@@ -302,7 +302,7 @@ class ContactTest(BaseFlowsTest):
 
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
         self.runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
-        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
+        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_uuid())
         self.context = self.run.build_context(self.runner, None)
 
     def test_to_and_from_json(self):
@@ -475,7 +475,7 @@ class FlowTest(BaseFlowsTest):
         runner = Runner(flows, now=datetime.datetime(2015, 10, 15, 7, 48, 30, 123456, pytz.UTC))
 
         # and start our parent flow
-        run = runner.start(self.org, [], self.contact, flows[0].get_id())
+        run = runner.start(self.org, [], self.contact, flows[0].get_uuid())
 
         # starting the flow should get us our initial prompt
         self.assertEqual(1, len(get_messages(run)))
@@ -607,7 +607,7 @@ class InteractionTest(BaseFlowsTest):
         run = None
         while True:
             if not run:
-                run = runner.start(test.org, test.fields_initial, test.contact_initial, flow.get_id())
+                run = runner.start(test.org, test.fields_initial, test.contact_initial, flow.get_uuid())
             else:
                 message = test.messages.pop(0)
                 self.assertEqual("input", message.type)
@@ -684,7 +684,7 @@ class InputTest(BaseFlowsTest):
 
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
         self.runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
-        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
+        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_uuid())
         self.context = self.run.build_context(self.runner, None)
 
     def test_build_context(self):
@@ -768,7 +768,7 @@ class RunnerTest(BaseFlowsTest):
     def test_start_and_resume_mushrooms(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
 
-        run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
+        run = self.runner.start(self.org, self.fields, self.contact, flow.get_uuid())
 
         self.assertEqual(run.org.primary_language, "eng")
         self.assertEqual(run.org.timezone, pytz.timezone("Africa/Kigali"))
@@ -874,7 +874,7 @@ class RunnerTest(BaseFlowsTest):
 
         jean = Contact("1234-1234", "Jean D'Amour", [ContactUrn.from_string("tel:+260964153686")], OrderedSet(), {}, "fre")
 
-        run = self.runner.start(self.org, self.fields, jean, flow.get_id())
+        run = self.runner.start(self.org, self.fields, jean, flow.get_uuid())
 
         self.assertEqual(run.contact.language, "fre")
         self.assertEqual(len(run.steps), 2)
@@ -912,7 +912,7 @@ class RunnerTest(BaseFlowsTest):
 
     def test_start_and_resume_greatwall(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/greatwall.json")))
-        run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
+        run = self.runner.start(self.org, self.fields, self.contact, flow.get_uuid())
 
         self.assertEqual(run.steps[0].node.uuid, "8dbb7e1a-43d6-4c5b-a99d-fe3ee8923b65")
         self.assertEqual(len(run.steps[0].actions), 1)
@@ -955,7 +955,7 @@ class RunnerTest(BaseFlowsTest):
     def test_start_and_resume_media(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/media.json")))
 
-        run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
+        run = self.runner.start(self.org, self.fields, self.contact, flow.get_uuid())
 
         self.assertEqual(run.steps[0].node.uuid, "ede3844f-9469-49a6-a419-5cdd3e5f99df")
         self.assertEqual(len(run.steps[0].actions), 1)
@@ -1016,14 +1016,14 @@ class RunnerTest(BaseFlowsTest):
     def test_start_with_empty_flow(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/empty.json")))
         runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
-        self.assertRaises(FlowRunException, runner.start, self.org, self.fields, self.contact, flow.get_id())
+        self.assertRaises(FlowRunException, runner.start, self.org, self.fields, self.contact, flow.get_uuid())
 
     def test_update_contact_field(self):
         self.fields.append(Field("district", "District", Field.ValueType.DISTRICT))
 
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
         runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
-        run = runner.start(self.org, self.fields, self.contact, flow.get_id())
+        run = runner.start(self.org, self.fields, self.contact, flow.get_uuid())
 
         runner.update_contact_field(run, "district", "Gasabo")
 
@@ -1041,7 +1041,7 @@ class RunnerTest(BaseFlowsTest):
 
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
         runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
-        run = runner.start(self.org, self.fields, self.contact, flow.get_id())
+        run = runner.start(self.org, self.fields, self.contact, flow.get_uuid())
 
         run.get_or_create_field("state", "State", Field.ValueType.STATE)
         run.get_or_create_field("district", "District", Field.ValueType.DISTRICT)
@@ -1081,14 +1081,14 @@ class RunStateTest(BaseFlowsTest):
     def test_to_and_from_json(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
         runner = Runner([flow])
-        run = runner.start(self.org, self.fields, self.contact, flow.get_id())
+        run = runner.start(self.org, self.fields, self.contact, flow.get_uuid())
 
         # send our first message through so we have references to rules
         runner.resume(run, Input("Yes"))
 
         # export to json and re-import
         json_str = json.dumps(run.to_json())
-        restored = RunState.from_json(json.loads(json_str), {flow.get_id(): flow})
+        restored = RunState.from_json(json.loads(json_str), {flow.get_uuid(): flow})
 
         # json should be the same
         self.assertEqual(json.dumps(restored.to_json()), json_str)
@@ -1098,7 +1098,7 @@ class StepTest(BaseFlowsTest):
 
     def test_to_and_from_json(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
-        deserialization_context = Flow.DeserializationContext({flow.get_id(): flow})
+        deserialization_context = Flow.DeserializationContext({flow.get_uuid(): flow})
         arrived_on = datetime.datetime(2015, 8, 25, 11, 59, 30, 88000, pytz.UTC)
 
         step = Step(flow, flow.entry, arrived_on)
@@ -1111,7 +1111,7 @@ class StepTest(BaseFlowsTest):
                                     'rule': None,
                                     'actions': [],
                                     'errors': [],
-                                    'flow_id': 17576})
+                                    'flow_uuid': '73c40f19-007d-46bd-83ea-aef439de9f9c'})
 
         step.add_action_result(Action.Result.performed(ReplyAction(TranslatableText("Hi Joe"))))
         json_obj = step.to_json()
@@ -1122,7 +1122,7 @@ class StepTest(BaseFlowsTest):
                                     'rule': None,
                                     'actions': [{'type': "reply", 'msg': "Hi Joe"}],
                                     'errors': [],
-                                    'flow_id': 17576})
+                                    'flow_uuid': '73c40f19-007d-46bd-83ea-aef439de9f9c'})
 
         step.add_action_result(Action.Result.performed(None, ["This is an error", "This too"]))
         json_obj = step.to_json()
@@ -1133,7 +1133,7 @@ class StepTest(BaseFlowsTest):
                                     'rule': None,
                                     'actions': [{'type': "reply", 'msg': "Hi Joe"}],
                                     'errors': ["This is an error", "This too"],
-                                    'flow_id': 17576})
+                                    'flow_uuid': '73c40f19-007d-46bd-83ea-aef439de9f9c'})
 
         step = Step.from_json(json_obj, deserialization_context)
 
@@ -1156,7 +1156,7 @@ class StepTest(BaseFlowsTest):
                                     'arrived_on': "2015-08-25T11:59:30.088Z",
                                     'left_on': None,
                                     'rule': {
-                                        'flow_id': 17576,
+                                        'flow_uuid': '73c40f19-007d-46bd-83ea-aef439de9f9c',
                                         'uuid': "a53e3607-ac87-4bee-ab95-30fd4ad8a837",
                                         "value": "yes",
                                         "media": None,
@@ -1164,7 +1164,7 @@ class StepTest(BaseFlowsTest):
                                         "text": "yes ok"},
                                     'actions': [],
                                     'errors': [],
-                                    'flow_id': 17576})
+                                    'flow_uuid': '73c40f19-007d-46bd-83ea-aef439de9f9c'})
 
         step = Step.from_json(json_obj, deserialization_context)
 
@@ -1188,7 +1188,7 @@ class TestsTest(BaseFlowsTest):
         self.deserialization_context = Flow.DeserializationContext(flows)
 
         self.runner = Runner(flows, location_resolver=BaseFlowsTest.TestLocationResolver())
-        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
+        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_uuid())
         self.context = self.run.build_context(self.runner, None)
 
     def assertTest(self, test, input, expected_matched, expected_value):

--- a/python/temba_flows/tests.py
+++ b/python/temba_flows/tests.py
@@ -465,7 +465,6 @@ class FlowTest(BaseFlowsTest):
                         msgs.append(action.msg)
             return msgs
 
-
         # read in our subflow import and create flow defs
         subflow_import = json.loads(self.read_resource('test_flows/subflow.json'))
         flows = []

--- a/python/temba_flows/tests.py
+++ b/python/temba_flows/tests.py
@@ -11,7 +11,7 @@ from ordered_set import OrderedSet
 from temba_expressions.dates import DateStyle
 from temba_expressions.evaluator import EvaluationContext
 from .definition import ContactRef, GroupRef, LabelRef, VariableRef
-from .definition.flow import Flow, Action, ActionSet, RuleSet
+from .definition.flow import Flow, Action, ActionSet, RuleSet, MessageAction
 from .definition.actions import ReplyAction, SendAction, EmailAction, SaveToContactAction, SetLanguageAction
 from .definition.actions import AddToGroupsAction, RemoveFromGroupsAction, AddLabelsAction
 from .definition.tests import *
@@ -90,8 +90,8 @@ class ActionsTest(BaseFlowsTest):
 
         self.deserialization_context = Flow.DeserializationContext(flow)
 
-        self.runner = Runner(location_resolver=BaseFlowsTest.TestLocationResolver())
-        self.run = self.runner.start(self.org, self.fields, self.contact, flow)
+        self.runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
+        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
         self.context = self.run.build_context(self.runner, None)
 
     def test_reply_action(self):
@@ -301,8 +301,8 @@ class ContactTest(BaseFlowsTest):
         super(ContactTest, self).setUp()
 
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
-        self.runner = Runner(location_resolver=BaseFlowsTest.TestLocationResolver())
-        self.run = self.runner.start(self.org, self.fields, self.contact, flow)
+        self.runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
+        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
         self.context = self.run.build_context(self.runner, None)
 
     def test_to_and_from_json(self):
@@ -451,6 +451,52 @@ class FieldTest(BaseFlowsTest):
 
 class FlowTest(BaseFlowsTest):
 
+    def test_subflows(self):
+
+        class TestLocationResolver(Location.Resolver):
+            def resolve(self, input, country, level, parent):
+                return None
+
+        def get_messages(run):
+            msgs = []
+            for step in run.get_completed_steps():
+                for action in step.actions:
+                    if isinstance(action, MessageAction):
+                        msgs.append(action.msg)
+            return msgs
+
+
+        # read in our subflow import and create flow defs
+        subflow_import = json.loads(self.read_resource('test_flows/subflow.json'))
+        flows = []
+        for flow_json in subflow_import['flows']:
+            flows.append(Flow.from_json(flow_json))
+
+        runner = Runner(flows, now=datetime.datetime(2015, 10, 15, 7, 48, 30, 123456, pytz.UTC))
+
+        # and start our parent flow
+        run = runner.start(self.org, [], self.contact, flows[0].get_id())
+
+        # starting the flow should get us our initial prompt
+        self.assertEqual(1, len(get_messages(run)))
+        self.assertEqual('This is a parent flow. What would you like to do?', get_messages(run)[0].value)
+
+        # respond with "color" which should launch the color subflow
+        run = runner.resume(run, Input("color"))
+
+        # our returned RunState should be for our child flow
+        self.assertEqual('What color do you like?', get_messages(run)[0].value)
+
+        # submit in our subflow which should complete it and take us to the parent
+        run = runner.resume(run, Input('red'))
+        self.assertEqual('Complete: You picked Red.', get_messages(run)[0].value)
+        self.assertEqual('This is a parent flow. What would you like to do?', get_messages(run)[1].value)
+
+        # run our subflow a second time in the same parent
+        run = runner.resume(run, Input("color"))
+        run = runner.resume(run, Input("green"))
+        self.assertEqual('Complete: You picked Green.', get_messages(run)[0].value)
+
     def test_from_json(self):
         flow = Flow.from_json(json.loads(self.read_resource('test_flows/mushrooms.json')))
 
@@ -551,7 +597,7 @@ class InteractionTest(BaseFlowsTest):
 
         interactions_json = json.loads(self.read_resource(interactions_file))
         tests = [InteractionTest.TestDefinition.from_json(t) for t in interactions_json]
-        runner = Runner(location_resolver=InteractionTest.TestLocationResolver(),
+        runner = Runner([flow], location_resolver=InteractionTest.TestLocationResolver(),
                         now=datetime.datetime(2015, 10, 15, 7, 48, 30, 123456, pytz.UTC))
 
         for test in tests:
@@ -561,7 +607,7 @@ class InteractionTest(BaseFlowsTest):
         run = None
         while True:
             if not run:
-                run = runner.start(test.org, test.fields_initial, test.contact_initial, flow)
+                run = runner.start(test.org, test.fields_initial, test.contact_initial, flow.get_id())
             else:
                 message = test.messages.pop(0)
                 self.assertEqual("input", message.type)
@@ -637,8 +683,8 @@ class InputTest(BaseFlowsTest):
         super(InputTest, self).setUp()
 
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
-        self.runner = Runner(location_resolver=BaseFlowsTest.TestLocationResolver())
-        self.run = self.runner.start(self.org, self.fields, self.contact, flow)
+        self.runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
+        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
         self.context = self.run.build_context(self.runner, None)
 
     def test_build_context(self):
@@ -713,12 +759,16 @@ class RunnerTest(BaseFlowsTest):
     def setUp(self):
         super(RunnerTest, self).setUp()
 
-        self.runner = Runner()
+        self.runner = Runner([
+            Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json"))),
+            Flow.from_json(json.loads(self.read_resource("test_flows/media.json"))),
+            Flow.from_json(json.loads(self.read_resource("test_flows/greatwall.json")))
+        ])
 
     def test_start_and_resume_mushrooms(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
 
-        run = self.runner.start(self.org, self.fields, self.contact, flow)
+        run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
 
         self.assertEqual(run.org.primary_language, "eng")
         self.assertEqual(run.org.timezone, pytz.timezone("Africa/Kigali"))
@@ -748,7 +798,7 @@ class RunnerTest(BaseFlowsTest):
         self.assertIsNone(run.steps[1].rule_result)
         self.assertEqual(len(run.get_completed_steps()), 1)
 
-        self.assertEqual(len(run.values), 0)
+        self.assertEqual(len(run.get_values()), 0)
 
         self.assertEqual(run.state, RunState.State.WAIT_MESSAGE)
 
@@ -776,11 +826,11 @@ class RunnerTest(BaseFlowsTest):
         self.assertIsNone(run.steps[2].left_on)
         self.assertEqual(len(run.get_completed_steps()), 2)
 
-        self.assertEqual(len(run.values), 1)
-        self.assertEqual(run.values["response_1"].value, "YUCK!")
-        self.assertEqual(run.values["response_1"].category, "Other")
-        self.assertEqual(run.values["response_1"].text, "YUCK!")
-        self.assertIsNotNone(run.values["response_1"].time)
+        self.assertEqual(len(run.get_values()), 1)
+        self.assertEqual(run.get_values()["response_1"].value, "YUCK!")
+        self.assertEqual(run.get_values()["response_1"].category, "Other")
+        self.assertEqual(run.get_values()["response_1"].text, "YUCK!")
+        self.assertIsNotNone(run.get_values()["response_1"].time)
 
         self.assertEqual(run.state, RunState.State.WAIT_MESSAGE)
 
@@ -811,11 +861,11 @@ class RunnerTest(BaseFlowsTest):
         self.assertEqual(len(run.steps[2].actions), 1)
         self.assertEqual(len(run.get_completed_steps()), 3)
 
-        self.assertEqual(len(run.values), 1)
-        self.assertEqual(run.values["response_1"].value, "no")
-        self.assertEqual(run.values["response_1"].category, "No")
-        self.assertEqual(run.values["response_1"].text, "no way")
-        self.assertIsNotNone(run.values["response_1"].time)
+        self.assertEqual(len(run.get_values()), 1)
+        self.assertEqual(run.get_values()["response_1"].value, "no")
+        self.assertEqual(run.get_values()["response_1"].category, "No")
+        self.assertEqual(run.get_values()["response_1"].text, "no way")
+        self.assertIsNotNone(run.get_values()["response_1"].time)
 
         self.assertEqual(run.state, RunState.State.COMPLETED)
 
@@ -824,7 +874,7 @@ class RunnerTest(BaseFlowsTest):
 
         jean = Contact("1234-1234", "Jean D'Amour", [ContactUrn.from_string("tel:+260964153686")], OrderedSet(), {}, "fre")
 
-        run = self.runner.start(self.org, self.fields, jean, flow)
+        run = self.runner.start(self.org, self.fields, jean, flow.get_id())
 
         self.assertEqual(run.contact.language, "fre")
         self.assertEqual(len(run.steps), 2)
@@ -833,13 +883,16 @@ class RunnerTest(BaseFlowsTest):
 
         self.runner.resume(run, Input("EUGH!"))
 
+        print run.steps[0].rule_result.__dict__
+
+
         self.assertEqual(run.steps[0].rule_result.category, "Other")
         self.assertEqual(run.steps[0].rule_result.value, "EUGH!")
         self.assertReply(run.steps[1].actions[0], "Nous ne comprenions pas votre réponse. S'il vous plaît répondre par oui/non.")
 
-        self.assertEqual(run.values["response_1"].value, "EUGH!")
-        self.assertEqual(run.values["response_1"].category, "Other")
-        self.assertEqual(run.values["response_1"].text, "EUGH!")
+        self.assertEqual(run.get_values()["response_1"].value, "EUGH!")
+        self.assertEqual(run.get_values()["response_1"].category, "Other")
+        self.assertEqual(run.get_values()["response_1"].text, "EUGH!")
 
         self.assertEqual(run.state, RunState.State.WAIT_MESSAGE)
 
@@ -851,16 +904,15 @@ class RunnerTest(BaseFlowsTest):
         self.assertEqual(run.steps[0].rule_result.value, "non")
         self.assertReply(run.steps[1].actions[0], "Ce fut la bonne réponse.")
 
-        self.assertEqual(run.values["response_1"].value, "non")
-        self.assertEqual(run.values["response_1"].category, "No")
-        self.assertEqual(run.values["response_1"].text, "non!!")
+        self.assertEqual(run.get_values()["response_1"].value, "non")
+        self.assertEqual(run.get_values()["response_1"].category, "No")
+        self.assertEqual(run.get_values()["response_1"].text, "non!!")
 
         self.assertEqual(run.state, RunState.State.COMPLETED)
 
     def test_start_and_resume_greatwall(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/greatwall.json")))
-
-        run = self.runner.start(self.org, self.fields, self.contact, flow)
+        run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
 
         self.assertEqual(run.steps[0].node.uuid, "8dbb7e1a-43d6-4c5b-a99d-fe3ee8923b65")
         self.assertEqual(len(run.steps[0].actions), 1)
@@ -878,9 +930,10 @@ class RunnerTest(BaseFlowsTest):
         self.assertReply(run.steps[1].actions[0], "Please choose a number between 1 and 8")
         self.assertEqual(run.steps[2].node.uuid, "b7cfa0ac-4d50-4384-a1ab-9ec79bd45e42")
 
-        self.assertEqual(run.values["people"].value, "9")
-        self.assertEqual(run.values["people"].category, "Other")
-        self.assertEqual(run.values["people"].text, "9")
+        values = run.get_values()
+        self.assertEqual(values["people"].value, "9")
+        self.assertEqual(values["people"].category, "Other")
+        self.assertEqual(values["people"].text, "9")
 
         self.runner.resume(run, Input("7"))
 
@@ -891,17 +944,18 @@ class RunnerTest(BaseFlowsTest):
         self.assertEqual(run.steps[1].rule_result.category, "> 2")
         self.assertEqual(run.steps[1].rule_result.value, "7")
 
-        self.assertEqual(run.values["people"].value, "7")
-        self.assertEqual(run.values["people"].category, "1 - 8")
-        self.assertEqual(run.values["people"].text, "7")
-        self.assertEqual(run.values["enough_for_soup"].value, "7")
-        self.assertEqual(run.values["enough_for_soup"].category, "> 2")
-        self.assertEqual(run.values["enough_for_soup"].text, "7")
+        values = run.get_values()
+        self.assertEqual(values["people"].value, "7")
+        self.assertEqual(values["people"].category, "1 - 8")
+        self.assertEqual(values["people"].text, "7")
+        self.assertEqual(values["enough_for_soup"].value, "7")
+        self.assertEqual(values["enough_for_soup"].category, "> 2")
+        self.assertEqual(values["enough_for_soup"].text, "7")
 
     def test_start_and_resume_media(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/media.json")))
 
-        run = self.runner.start(self.org, self.fields, self.contact, flow)
+        run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
 
         self.assertEqual(run.steps[0].node.uuid, "ede3844f-9469-49a6-a419-5cdd3e5f99df")
         self.assertEqual(len(run.steps[0].actions), 1)
@@ -938,9 +992,10 @@ class RunnerTest(BaseFlowsTest):
         self.assertEqual(len(current.actions), 1)
         self.assertReply(current.actions[0], 'What kind of media?')
 
-        self.assertEqual(run.values["photo"].text, "file://location/image.png")
-        self.assertEqual(run.values["photo"].value, "file://location/image.png")
-        self.assertEqual(run.values["photo"].category, "All Responses")
+        values = run.get_values()
+        self.assertEqual(values["photo"].text, "file://location/image.png")
+        self.assertEqual(values["photo"].value, "file://location/image.png")
+        self.assertEqual(values["photo"].category, "All Responses")
 
         # other media types
         self.runner.resume(run, Input("video"))
@@ -953,21 +1008,22 @@ class RunnerTest(BaseFlowsTest):
         self.runner.resume(run, Input("123,456", media_type="geo"))
 
         # check those responses ultimately make it through as well
-        self.assertEqual(run.values["video"].value, "file://location/video.mp4")
-        self.assertEqual(run.values["audio"].value, "file://location/audio.wav")
-        self.assertEqual(run.values["location"].value, "123,456")
+        values = run.get_values()
+        self.assertEqual(values["video"].value, "file://location/video.mp4")
+        self.assertEqual(values["audio"].value, "file://location/audio.wav")
+        self.assertEqual(values["location"].value, "123,456")
 
     def test_start_with_empty_flow(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/empty.json")))
-        self.assertRaises(FlowRunException, self.runner.start, self.org, self.fields, self.contact, flow)
+        runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
+        self.assertRaises(FlowRunException, runner.start, self.org, self.fields, self.contact, flow.get_id())
 
     def test_update_contact_field(self):
         self.fields.append(Field("district", "District", Field.ValueType.DISTRICT))
 
-        runner = Runner(location_resolver=BaseFlowsTest.TestLocationResolver())
-
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
-        run = runner.start(self.org, self.fields, self.contact, flow)
+        runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
+        run = runner.start(self.org, self.fields, self.contact, flow.get_id())
 
         runner.update_contact_field(run, "district", "Gasabo")
 
@@ -983,9 +1039,9 @@ class RunnerTest(BaseFlowsTest):
 
     def test_update_contact_ward_field(self):
 
-        runner = Runner(location_resolver=BaseFlowsTest.TestLocationResolver())
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
-        run = runner.start(self.org, self.fields, self.contact, flow)
+        runner = Runner([flow], location_resolver=BaseFlowsTest.TestLocationResolver())
+        run = runner.start(self.org, self.fields, self.contact, flow.get_id())
 
         run.get_or_create_field("state", "State", Field.ValueType.STATE)
         run.get_or_create_field("district", "District", Field.ValueType.DISTRICT)
@@ -1024,15 +1080,15 @@ class RunStateTest(BaseFlowsTest):
 
     def test_to_and_from_json(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
-        runner = Runner()
-        run = runner.start(self.org, self.fields, self.contact, flow)
+        runner = Runner([flow])
+        run = runner.start(self.org, self.fields, self.contact, flow.get_id())
 
         # send our first message through so we have references to rules
         runner.resume(run, Input("Yes"))
 
         # export to json and re-import
         json_str = json.dumps(run.to_json())
-        restored = RunState.from_json(json.loads(json_str), flow)
+        restored = RunState.from_json(json.loads(json_str), {flow.get_id(): flow})
 
         # json should be the same
         self.assertEqual(json.dumps(restored.to_json()), json_str)
@@ -1042,10 +1098,10 @@ class StepTest(BaseFlowsTest):
 
     def test_to_and_from_json(self):
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
-        deserialization_context = Flow.DeserializationContext(flow)
+        deserialization_context = Flow.DeserializationContext({flow.get_id(): flow})
         arrived_on = datetime.datetime(2015, 8, 25, 11, 59, 30, 88000, pytz.UTC)
 
-        step = Step(flow.entry, arrived_on)
+        step = Step(flow, flow.entry, arrived_on)
 
         json_obj = step.to_json()
 
@@ -1054,7 +1110,8 @@ class StepTest(BaseFlowsTest):
                                     'left_on': None,
                                     'rule': None,
                                     'actions': [],
-                                    'errors': []})
+                                    'errors': [],
+                                    'flow_id': 17576})
 
         step.add_action_result(Action.Result.performed(ReplyAction(TranslatableText("Hi Joe"))))
         json_obj = step.to_json()
@@ -1064,7 +1121,8 @@ class StepTest(BaseFlowsTest):
                                     'left_on': None,
                                     'rule': None,
                                     'actions': [{'type': "reply", 'msg': "Hi Joe"}],
-                                    'errors': []})
+                                    'errors': [],
+                                    'flow_id': 17576})
 
         step.add_action_result(Action.Result.performed(None, ["This is an error", "This too"]))
         json_obj = step.to_json()
@@ -1074,7 +1132,8 @@ class StepTest(BaseFlowsTest):
                                     'left_on': None,
                                     'rule': None,
                                     'actions': [{'type': "reply", 'msg': "Hi Joe"}],
-                                    'errors': ["This is an error", "This too"]})
+                                    'errors': ["This is an error", "This too"],
+                                    'flow_id': 17576})
 
         step = Step.from_json(json_obj, deserialization_context)
 
@@ -1090,20 +1149,22 @@ class StepTest(BaseFlowsTest):
 
         yes_rule = flow.entry.destination.rules[0]
 
-        step.rule_result = RuleSet.Result(yes_rule, "yes", "Yes", "yes ok")
+        step.rule_result = RuleSet.Result(flow, yes_rule, "yes", "Yes", "yes ok")
         json_obj = step.to_json()
 
         self.assertEqual(json_obj, {'node': "32cf414b-35e3-4c75-8a78-d5f4de925e13",
                                     'arrived_on': "2015-08-25T11:59:30.088Z",
                                     'left_on': None,
                                     'rule': {
+                                        'flow_id': 17576,
                                         'uuid': "a53e3607-ac87-4bee-ab95-30fd4ad8a837",
                                         "value": "yes",
                                         "media": None,
                                         "category": "Yes",
                                         "text": "yes ok"},
                                     'actions': [],
-                                    'errors': []})
+                                    'errors': [],
+                                    'flow_id': 17576})
 
         step = Step.from_json(json_obj, deserialization_context)
 
@@ -1123,11 +1184,11 @@ class TestsTest(BaseFlowsTest):
         super(TestsTest, self).setUp()
 
         flow = Flow.from_json(json.loads(self.read_resource("test_flows/mushrooms.json")))
+        flows = [flow]
+        self.deserialization_context = Flow.DeserializationContext(flows)
 
-        self.deserialization_context = Flow.DeserializationContext(flow)
-
-        self.runner = Runner(location_resolver=BaseFlowsTest.TestLocationResolver())
-        self.run = self.runner.start(self.org, self.fields, self.contact, flow)
+        self.runner = Runner(flows, location_resolver=BaseFlowsTest.TestLocationResolver())
+        self.run = self.runner.start(self.org, self.fields, self.contact, flow.get_id())
         self.context = self.run.build_context(self.runner, None)
 
     def assertTest(self, test, input, expected_matched, expected_value):


### PR DESCRIPTION
Adds subflow support for both java and python flow engines.

 * Adds flow references to steps which the caller needs to be mindful of so they know which flow a particular step is part of. Calls to resume can now return steps from more than one flow.
 * Uses a single RunState as it dips in and out of subflows